### PR TITLE
Fix vcxproj path to node_modules

### DIFF
--- a/src/windows/SliderWindows/SliderWindows.vcxproj
+++ b/src/windows/SliderWindows/SliderWindows.vcxproj
@@ -70,8 +70,11 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
+  <PropertyGroup>
+    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
+  </PropertyGroup>
   <ImportGroup Label="Shared">
-    <Import Project="..\..\..\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems" Label="Shared" />
+    <Import Project="$(ReactNativeWindowsDir)\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems" Label="Shared" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -153,7 +156,7 @@
     </Text>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\node_modules\react-native-windows\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj">
+    <ProjectReference Include="$(ReactNativeWindowsDir)\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj">
       <Project>{f7d32bd0-2749-483e-9a0d-1635ef7e3136}</Project>
       <Private>false</Private>
     </ProjectReference>


### PR DESCRIPTION
Summary:
---------

Currently, manually linking the react-native-slider to a react-native-windows project requires additional modifications to the vcxproj file located in the node_modules while other projects such as [Picker](https://github.com/react-native-picker/react-native-picker) do not.

Note: Code was copied from [Picker](https://github.com/react-native-picker/react-native-picker/blob/master/windows/ReactNativePicker/ReactNativePicker.vcxproj) vsxproj.

Test Plan:
----------

Perform the manual linking steps on Windows described in the README. Should work on a brand new react-native project created through these [steps](https://microsoft.github.io/react-native-windows/docs/getting-started).