### PR TITLE
fix: useEffect should not return a value

### DIFF
--- a/src/js/RNCSliderNativeComponent.web.js
+++ b/src/js/RNCSliderNativeComponent.web.js
@@ -184,10 +184,9 @@ const RCTSliderWebComponent = React.forwardRef(
     const containerRef = forwardedRef || React.createRef();
     const hasBeenResized = React.useRef(false);
     const [value, setValue] = React.useState(initialValue || minimumValue);
-    React.useLayoutEffect(() => updateValue(initialValue), [
-      initialValue,
-      updateValue,
-    ]);
+    React.useLayoutEffect(() => {
+      updateValue(initialValue);
+    }, [initialValue, updateValue]);
 
     const percentageValue =
       (value - minimumValue) / (maximumValue - minimumValue);


### PR DESCRIPTION
Summary:
---------

The function inside `useEffect` shouldn't return a value, it can only return a function or nothing

This solves this warning:
```
Warning: An effect function must not return anything besides a function, which is used for clean-up. You returned: 0
    in RTCSliderWebComponent (at Slider.js:279)
```

It also fixes an error that was breaking the slide in my rn-web app:

<img width="979" alt="Screenshot 2020-10-20 at 12 20 59" src="https://user-images.githubusercontent.com/11232797/96573620-b853e180-12ce-11eb-8e77-ec212f4ca369.png">

Test Plan:
----------

Tested on the examples