### PR TITLE
Resolve Missing Deploy Target Issue

### DIFF
--- a/src/windows/SliderWindows/SliderWindows.vcxproj
+++ b/src/windows/SliderWindows/SliderWindows.vcxproj
@@ -165,6 +165,7 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
+  <Target Name="Deploy"/>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>


### PR DESCRIPTION
Summary:
---------

Fix error produced when module is added to a React Native app and run in Windows emulator.
Error reads: "The target "Deploy" does not exist in the project".

Test Plan:
----------

Create a React Native Windows app.
Add datetimepicker module to app via yarn add.
Run npx react-native run-windows.
If app deploys successfully and loads in the Windows emulator, the code change has succeeded.