### PR TITLE
Fix accessibility-related crash on Android 4.x (#220).

### DIFF
--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -109,9 +109,12 @@ public class ReactSlider extends AppCompatSeekBar {
   @Override
   public void onPopulateAccessibilityEvent(AccessibilityEvent event) {
     super.onPopulateAccessibilityEvent(event);
-    if (event.getEventType() == AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED ||
-        (event.getEventType() == AccessibilityEvent.TYPE_VIEW_SELECTED && this.isAccessibilityFocused())) {
-      this.setupAccessibility();
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      if (event.getEventType() == AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED ||
+          (event.getEventType() == AccessibilityEvent.TYPE_VIEW_SELECTED && this.isAccessibilityFocused())) {
+          this.setupAccessibility();
+      }
     }
   }
 


### PR DESCRIPTION
Avoid calling isAccessibilityFocused() on Android < Lollipop.

Summary:
---------

Fixes issue #220.


Test Plan:
----------
We reproduced a crash on an Android 4.1 emulator, applied this patch, and observed that the crash no longer occurred.