### PR TITLE
Fix crash when step property is missing on Windows.

### DIFF
--- a/src/windows/SliderWindows/SliderView.cpp
+++ b/src/windows/SliderWindows/SliderView.cpp
@@ -80,7 +80,7 @@ namespace winrt::SliderWindows::implementation {
                 }
                 else {
                     updatedMaxValue = true;
-                    m_maxValue = propertyValue.AsInt64();
+                    m_maxValue = propertyValue.AsDouble();
                 }
             }
             else if (propertyName == "minimumValue") {
@@ -89,15 +89,18 @@ namespace winrt::SliderWindows::implementation {
                 }
                 else {
                     updatedMinValue = true;
-                    m_minValue = propertyValue.AsInt64();
+                    m_minValue = propertyValue.AsDouble();
                 }
             }
             else if (propertyName == "step") {
                 if (propertyValue.IsNull()) {
                     this->ClearValue(xaml::Controls::Slider::StepFrequencyProperty());
                 }
-                else {
+                else if (propertyValue.AsDouble() != 0) {
                     this->StepFrequency(propertyValue.AsDouble());
+                }
+                else {
+                    this->StepFrequency(c_stepDefault);
                 }
             }
             else if (propertyName == "inverted") {

--- a/src/windows/SliderWindows/SliderView.h
+++ b/src/windows/SliderWindows/SliderView.h
@@ -35,8 +35,8 @@ namespace winrt::SliderWindows::implementation {
             winrt::Windows::Foundation::IInspectable const& sender,
             xaml::Input::ManipulationCompletedRoutedEventArgs const& args);
         
-        int64_t m_maxValue, m_minValue;
-        double m_value;
+        double m_value, m_maxValue, m_minValue;
+        const double c_stepDefault = 0.1;
     };
 }
 


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->
On Windows, if the `step` property is not specified, the app crashes when trying to move the slider - adding a default value in the native code to prevent that (the default in JS doesn't work).

Also, fixing a casting bug where min/max values get trimmed if fractions are provided.

Fixes #256 