### PR TITLE
Fix: Slider default step causes crash on Windows OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Callback continuously called while the user is dragging the slider.
 
 Step value of the slider. The value should be between 0 and (maximumValue - minimumValue). Default value is 0.
 
+On Windows OS the default value is 1% of slider's range (from `minimumValue` to `maximumValue`).
+
 | Type   | Required |
 | ------ | -------- |
 | number | No       |

--- a/src/windows/SliderWindows/SliderView.cpp
+++ b/src/windows/SliderWindows/SliderView.cpp
@@ -96,11 +96,9 @@ namespace winrt::SliderWindows::implementation {
                 if (propertyValue.IsNull()) {
                     this->ClearValue(xaml::Controls::Slider::StepFrequencyProperty());
                 }
-                else if (propertyValue.AsDouble() != 0) {
-                    this->StepFrequency(propertyValue.AsDouble());
-                }
                 else {
-                    this->StepFrequency(c_stepDefault);
+                    auto&& step = CalculateStepFrequencyPercentageValue(propertyValue.AsDouble());
+                    this->StepFrequency(step);
                 }
             }
             else if (propertyName == "inverted") {
@@ -235,6 +233,15 @@ namespace winrt::SliderWindows::implementation {
                     }
                     eventDataWriter.WriteObjectEnd();
                 });
+        }
+    }
+
+    const double SliderView::CalculateStepFrequencyPercentageValue(const double& stepPropertyValue) const noexcept {
+        if (stepPropertyValue != 0) {
+            return stepPropertyValue;
+        }
+        else {
+            return (m_maxValue - m_minValue) / 100.f;
         }
     }
 }

--- a/src/windows/SliderWindows/SliderView.h
+++ b/src/windows/SliderWindows/SliderView.h
@@ -37,7 +37,7 @@ namespace winrt::SliderWindows::implementation {
 
         const double CalculateStepFrequencyPercentageValue(const double& stepPropertyValue) const noexcept;
 
-        int64_t m_maxValue, m_minValue;
+        double m_maxValue, m_minValue;
         double m_value;
     };
 }

--- a/src/windows/SliderWindows/SliderView.h
+++ b/src/windows/SliderWindows/SliderView.h
@@ -34,9 +34,11 @@ namespace winrt::SliderWindows::implementation {
         void OnManipulationCompletedHandler(
             winrt::Windows::Foundation::IInspectable const& sender,
             xaml::Input::ManipulationCompletedRoutedEventArgs const& args);
-        
-        double m_value, m_maxValue, m_minValue;
-        const double c_stepDefault = 0.1;
+
+        const double CalculateStepFrequencyPercentageValue(const double& stepPropertyValue) const noexcept;
+
+        int64_t m_maxValue, m_minValue;
+        double m_value;
     };
 }
 


### PR DESCRIPTION
This pull request fixes #256 

Summary:
---------

This PR provides the Slider with the fix for an application crashing when moving the Slider with a default value set for `<Step/>`.

The implementation introduces the similar approach to step's calculations as is already done for other platforms
(see implementation for [iOS](https://github.com/callstack/react-native-slider/blob/e7dd6eec8796832487afb886719ed622f575e5f6/src/ios/RNCSliderManager.m#L59-L61) and for [Android](https://github.com/callstack/react-native-slider/blob/e7dd6eec8796832487afb886719ed622f575e5f6/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java#L183-L185)).

The calculations done on Windows implementation returns the default step as 1% of available range: minimum to maximum.
NOTE: The implementation returns the calculated percentage value **in case of** original step being set to 0. This considers not only the default value, but also custom user value set to 0. This is intentional - during the analysis it turned out, that setting the value of slider's step to custom 0 the application also crashes with the same error.

For more information please see the commit messages.

Test Plan:
----------

Changes were tested manually with following scenarios:

**1.** Default step, minimumValue = 20, maximumValue = 140:
![SliderDefault20-140](https://user-images.githubusercontent.com/70535775/105823277-3ce48900-5fbd-11eb-8422-e1a4cec1c417.gif)

**2.** Default step, default minimum and maximum values:
![SliderDefault0-1](https://user-images.githubusercontent.com/70535775/105823578-9baa0280-5fbd-11eb-91db-d6066754cc05.gif)

**3.** Regression tests - step set at custom value of *1.234*, minimumValue = 34, maximumValue = 153
![SliderCustom](https://user-images.githubusercontent.com/70535775/105824264-681ba800-5fbe-11eb-927c-2ecd423b420f.gif)

