### PR TITLE
Fixed rounding problem, the cause of issue #264.

### DIFF
--- a/src/ios/RNCSliderManager.m
+++ b/src/ios/RNCSliderManager.m
@@ -79,11 +79,22 @@ RCT_EXPORT_MODULE()
 static float discreteValue(RNCSlider *sender, float value) {
   // If step is set and less than or equal to difference between max and min values,
   // pick the closest discrete multiple of step to return.
+
   if (sender.step > 0 && sender.step <= (sender.maximumValue - sender.minimumValue)) {
+    
+    // Round up when increase, round down when decrease.
+    double (^_round)(double) = ^(double x) {
+      if (sender.lastValue > value) {
+        return floor(x);
+      } else {
+        return ceil(x);
+      }
+    };
+  
     return
       MAX(sender.minimumValue,
         MIN(sender.maximumValue,
-          sender.minimumValue + round((value - sender.minimumValue) / sender.step) * sender.step
+            sender.minimumValue + _round((value - sender.minimumValue) / sender.step) * sender.step
         )
       );
   }


### PR DESCRIPTION
Summary:
There was an [issue](https://github.com/callstack/react-native-slider/issues/264) caused by rounding problem on iOS native side.
So the basic `round` function was replaced by `ceil` when the slider goes up, and with `floor` when the slider goes down.

The problem:
https://user-images.githubusercontent.com/12425395/115276870-069e4c00-a15d-11eb-805f-8b2f2e6f2208.MP4

Has gone...
https://user-images.githubusercontent.com/12425395/115276646-b58e5800-a15c-11eb-9266-45c3aeedb648.MP4

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
Manually check with VoiceOver and confirm that functional has not been changed, only the problem has gone.

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->