### PR TITLE
README updated and included in npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,19 +52,12 @@ import Slider from '@react-native-community/slider';
 
 Check out the [example project](example) for more examples.
 
-## React Native Compatibility
-To use this library you need to ensure you are using the correct version of React Native.
+---
 
-| `@react-native-community/slider` version | Required React Native Version |
-| ---------------------------------------- | ----------------------------- |
-| `4.x.x`                                  | `>=0.60`; `>=0.62` (on Windows);  |
-| `3.1.x`                                  | `>=0.60`                      |
-| `2.x.x`                                  | `>= 0.60`                     |
-| [`1.x.x`](https://github.com/react-native-community/react-native-slider/tree/937f0942f1fffc6ed88b5cf7c88d73b7878f00f0)  | `<= 0.59`                     |
+**Migrating from the core `react-native` module**
 
-
-## Migrating from the core `react-native` module
-This module was created when the Slider was split out from the core of React Native. To migrate to this module you need to follow the installation instructions above and then change you imports from:
+This module was created when the Slider was split out from the core of React Native.
+<br/>To migrate to this module you need to follow the installation instructions above and then change you imports from:
 
 ```javascript
 import { Slider } from 'react-native';
@@ -75,6 +68,16 @@ to:
 ```javascript
 import Slider from '@react-native-community/slider';
 ```
+
+## React Native Compatibility
+To use this library you need to ensure you are using the correct version of React Native.
+
+| `@react-native-community/slider` version | Required React Native Version |
+| ---------------------------------------- | ----------------------------- |
+| `4.x.x`                                  | `>=0.60`; `>=0.62` (on Windows);  |
+| `3.1.x`                                  | `>=0.60`                      |
+| `2.x.x`                                  | `>= 0.60`                     |
+| [`1.x.x`](https://github.com/react-native-community/react-native-slider/tree/937f0942f1fffc6ed88b5cf7c88d73b7878f00f0)  | `<= 0.59` |
 
 
 ## Properties

--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
-# `@react-native-community/slider`
-![npm](https://img.shields.io/npm/v/@react-native-community/slider.svg)
-![CircleCI Status](https://img.shields.io/circleci/project/github/callstack/react-native-slider/master.svg)
-![Supports Android, iOS, and Web](https://img.shields.io/badge/platforms-android%20|%20ios%20|%20windows%20|%20web-lightgrey.svg)
-![MIT License](https://img.shields.io/npm/l/@react-native-community/slider.svg)
+<p align="center">
+  <h1 align="center"> <code>@react-native-community/slider</code> </h1>
+</p>
+<p align="center">
+  React Native component used to select a single value from a range of values.
+</p>
+<p align="center">
+    <a href="https://www.npmjs.com/package/@react-native-community/slider">
+        <img src="https://img.shields.io/npm/v/@react-native-community/slider.svg" alt="Latest version released on npmjs" />
+    </a>
+    <a href="https://app.circleci.com/pipelines/github/callstack/react-native-slider?branch=master">
+        <img src="https://img.shields.io/circleci/project/github/callstack/react-native-slider/master.svg" alt="Build on CircleCI" />
+    </a>
+    <a href="https://github.com/callstack/react-native-slider">
+        <img src="https://img.shields.io/badge/platforms-android%20|%20ios%20|%20windows%20|%20web-lightgrey.svg" alt="Supported platforms" />
+    </a>
+    <a href="https://github.com/callstack/react-native-slider/blob/master/LICENSE.md">
+        <img src="https://img.shields.io/npm/l/@react-native-community/slider.svg" alt="License" />
+    </a>
+</p>
 
-React Native component used to select a single value from a range of values.
 
 ![iOS Screenshot](https://i.postimg.cc/dQTYzGD5/Screenshot-2019-03-25-at-11-24-59.png)
 ![Android Screenshot](https://i.postimg.cc/CKdtbVqc/Screenshot-2019-03-25-at-11-26-54.png)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
   <h1 align="center"> <code>@react-native-community/slider</code> </h1>
 </p>
 <p align="center">
-  React Native component used to select a single value from a range of values.
-</p>
-<p align="center">
     <a href="https://www.npmjs.com/package/@react-native-community/slider">
         <img src="https://img.shields.io/npm/v/@react-native-community/slider.svg" alt="Latest version released on npmjs" />
     </a>
@@ -18,11 +15,14 @@
         <img src="https://img.shields.io/npm/l/@react-native-community/slider.svg" alt="License" />
     </a>
 </p>
+<p align="center">
+  React Native component used to select a single value from a range of values.
+  <br>Currently supported on following platforms:
+</p>
 
-
-![iOS Screenshot](https://i.postimg.cc/dQTYzGD5/Screenshot-2019-03-25-at-11-24-59.png)
-![Android Screenshot](https://i.postimg.cc/CKdtbVqc/Screenshot-2019-03-25-at-11-26-54.png)
-![Windows Screenshot](example/sliderWindows.JPG)
+|iOS|Android|Windows|
+|:-:|:-:|:-:|
+|![iOS Screenshot](https://i.postimg.cc/dQTYzGD5/Screenshot-2019-03-25-at-11-24-59.png)|![Android Screenshot](https://i.postimg.cc/CKdtbVqc/Screenshot-2019-03-25-at-11-26-54.png)|![Windows Screenshot](example/sliderWindows.JPG)|
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -24,17 +24,33 @@
 |:-:|:-:|:-:|
 |![iOS Screenshot](https://i.postimg.cc/dQTYzGD5/Screenshot-2019-03-25-at-11-24-59.png)|![Android Screenshot](https://i.postimg.cc/CKdtbVqc/Screenshot-2019-03-25-at-11-26-54.png)|![Windows Screenshot](example/sliderWindows.JPG)|
 
-## Getting started
+## Installation & Usage
 
-`yarn add @react-native-community/slider`
+To install this module `cd` to your project directory and enter the following command:
+```
+yarn add @react-native-community/slider
+```
 or
-`npm install @react-native-community/slider --save`
+```
+npm install @react-native-community/slider --save
+```
+If using iOS please remember to install cocoapods by running: `npx pod-install`
+<br/>For web support please use `@react-native-community/slider@next`
 
-If using iOS, install cocoapods: `npx pod-install`
+The following code presents the basic usage scenario of this library:
+```javascript
+import Slider from '@react-native-community/slider';
 
-On Windows, autolinking is available from version 0.63. On 0.62 you need to [`manually link the module`](#Manual-linking-of-the-module-on-Windows) to your app. 
-You can see the example app's code for how to do it.
+<Slider
+  style={{width: 200, height: 40}}
+  minimumValue={0}
+  maximumValue={1}
+  minimumTrackTintColor="#FFFFFF"
+  maximumTrackTintColor="#000000"
+/>
+```
 
+Check out the [example project](example) for more examples.
 
 ## React Native Compatibility
 To use this library you need to ensure you are using the correct version of React Native.
@@ -46,9 +62,6 @@ To use this library you need to ensure you are using the correct version of Reac
 | `2.x.x`                                  | `>= 0.60`                     |
 | [`1.x.x`](https://github.com/react-native-community/react-native-slider/tree/937f0942f1fffc6ed88b5cf7c88d73b7878f00f0)  | `<= 0.59`                     |
 
-## Web support
-
-For web support please use `@react-native-community/slider@next`
 
 ## Migrating from the core `react-native` module
 This module was created when the Slider was split out from the core of React Native. To migrate to this module you need to follow the installation instructions above and then change you imports from:
@@ -63,25 +76,6 @@ to:
 import Slider from '@react-native-community/slider';
 ```
 
-## Usage
-
-### Example
-
-```javascript
-import Slider from '@react-native-community/slider';
-```
-
-```javascript
-  <Slider
-    style={{width: 200, height: 40}}
-    minimumValue={0}
-    maximumValue={1}
-    minimumTrackTintColor="#FFFFFF"
-    maximumTrackTintColor="#000000"
-  />
-```
-
-Check out the [example project](example) for more examples.
 
 ### Props
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # `@react-native-community/slider`
-![npm](https://img.shields.io/npm/v/@react-native-community/slider.svg)[![CircleCI Status](https://img.shields.io/circleci/project/github/react-native-community/react-native-slider/master.svg)](https://circleci.com/gh/react-native-community/workflows/react-native-slider/tree/master) ![Supports Android, iOS, and Web](https://img.shields.io/badge/platforms-android%20|%20ios%20|%20web-lightgrey.svg) ![MIT License](https://img.shields.io/npm/l/@react-native-community/slider.svg)
+![npm](https://img.shields.io/npm/v/@react-native-community/slider.svg)
+![CircleCI Status](https://img.shields.io/circleci/project/github/callstack/react-native-slider/master.svg)
+![Supports Android, iOS, and Web](https://img.shields.io/badge/platforms-android%20|%20ios%20|%20windows%20|%20web-lightgrey.svg)
+![MIT License](https://img.shields.io/npm/l/@react-native-community/slider.svg)
 
 React Native component used to select a single value from a range of values.
 

--- a/README.md
+++ b/README.md
@@ -111,33 +111,22 @@ To use this library you need to ensure you are using the correct version of Reac
 ## Contributing
 
 This project uses [yarn workspaces](https://classic.yarnpkg.com/en/docs/workspaces/) to handle its internal dependencies.
-Make sure to use `yarn` to install dependencies
-
+* Make sure to use `yarn` to install dependencies when implementing changes to this library.
 ```sh
 yarn install
 ```
-
-Make sure your code passes Flow, ESLint and the tests. Run the following to verify:
-
+* Make sure your code passes Flow, ESLint and the tests. Run the following to verify:
 ```sh
 yarn validate:flow
-yarn validate:eslint
+yarn validate:eslint --fix
 yarn test:jest
 ```
-
 or 
-
 ```sh
 yarn test
 ```
 to run them all.
-
-To fix formatting errors, run the following:
-
-```sh
-yarn validate:eslint --fix
-```
-Remember to cover your changes with tests if possible.
+* Remember to cover your changes with tests if possible.
 
 # Running the example app 
 While developing, you can run the example app to test your changes.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ While developing, you can run the example app to test your changes.
 
 ## Contributors
 
-This module was extracted from `react-native` core. Please, refer to https://github.com/react-native-community/react-native-slider/graphs/contributors for the complete list of contributors.
+This module was extracted from `react-native` core. Please, refer to [contributors graph](https://github.com/react-native-community/react-native-slider/graphs/contributors) for the complete list of contributors.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -156,30 +156,6 @@ While developing, you can run the example app to test your changes.
 - Run `yarn run:web` to run on web
 - Run `yarn run:windows` to run on Windows.
 
-# Manual linking of the module on Windows
-On Windows, you need to manually link the `Slider` native module to your project.
-
-#### Add the SliderWindows project to your solution
-
-1. Open the solution in Visual Studio 2019.
-2. Right-click solution icon in Solution Explorer > Add > Existing Project.
-   Select 'D:\pathToYourApp\node_modules\@react-native-community\slider\windows\SliderWindows\SliderWindows.vcxproj'.
-
-#### **windows/myapp.sln**
-
-Add a reference to `SliderWindows` to your main application project. From Visual Studio 2019:
-
-Right-click main application project > Add > Reference...
-Check 'SliderWindows' from the 'Project > Solution' tab on the left.
-
-#### **pch.h**
-
-Add `#include "winrt/SliderWindows.h"`.
-
-#### **app.cpp**
-
-Add `PackageProviders().Append(winrt::SliderWindows::ReactPackageProvider());` before `InitializeComponent();`.
-
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -157,5 +157,14 @@ While developing, you can run the example app to test your changes.
 
 This module was extracted from `react-native` core. Please, refer to https://github.com/react-native-community/react-native-slider/graphs/contributors for the complete list of contributors.
 
+---
+
+## Made with ❤️ at Callstack
+
+`@callstack/ReactNativeNotes` is an open source project and will always remain free to use. If you think it's cool, please star it 🌟. [Callstack](https://callstack.com/) is a group of React and React Native geeks, contact us at [hello@callstack.com](mailto:hello@callstack.com) if you need any help with these or just want to say hi!
+
+Like the project? ⚛️ [Join the team](https://callstack.com/careers) who does amazing stuff for clients and drives React Native Open Source! 🔥
+
+
 ## License
 The library is released under the MIT licence. For more information see `LICENSE`.

--- a/README.md
+++ b/README.md
@@ -77,241 +77,33 @@ import Slider from '@react-native-community/slider';
 ```
 
 
-### Props
+### Properties
+
+| Property | Description | Type | Required | Platform |
+| -------- | ----------- | ---- | -------- | -------- |
+| `style` | Used to style and layout the `Slider`. See `StyleSheet.js` and `ViewStylePropTypes.js` for more info. | View.style | No | |
+| `disabled`| If true the user won't be able to move the slider. Default value is false. | bool | No | |
+| `maximumValue` | Initial maximum value of the slider. Default value is 1. | number | No | |
+| `minimumTrackTintColor` | The color used for the track to the left of the button. Overrides the default blue gradient image on iOS. | [color](https://reactnative.dev/docs/colors) | No | |
+| `minimumValue` | Initial minimum value of the slider. Default value is 0. | number | No | |
+| `onSlidingStart` | Callback that is called when the user picks up the slider. The initial value is passed as an argument to the callback handler. | function | No | |
+| `onSlidingComplete` | Callback that is called when the user releases the slider, regardless if the value has changed. The current value is passed as an argument to the callback handler. | function | No | |
+| `onValueChange` | Callback continuously called while the user is dragging the slider. | function | No | |
+| `step` | Step value of the slider. The value should be between 0 and (maximumValue - minimumValue). Default value is 0. On Windows OS the default value is 1% of slider's range (from `minimumValue` to `maximumValue`). | number | No | |
+| `maximumTrackTintColor` | The color used for the track to the right of the button. Overrides the default gray gradient image on iOS. | [color](https://reactnative.dev/docs/colors) | No | |
+| `testID` | Used to locate this view in UI automation tests. | string | No | |
+| `value` | Initial value of the slider. The value should be between minimumValue and maximumValue, which default to 0 and 1 respectively. Default value is 0.<br/>_This is not a controlled component_, you don't need to update the value during dragging. | number | No | |
+| `tapToSeek` | Permits tapping on the slider track to set the thumb position. Defaults to false on iOS. No effect on Android or Windows. | bool | No | iOS |
+| `inverted` | Reverses the direction of the slider. Default value is false. | bool | No | |
+| `vertical` | Changes the orientation of the slider to vertical, if set to `true`. Default value is false. | bool | No | Windows |
+| `thumbTintColor` | Color of the foreground switch grip. | [color](https://reactnative.dev/docs/colors) | No | Android |
+| `maximumTrackImage` | Assigns a maximum track image. Only static images are supported. The leftmost pixel of the image will be stretched to fill the track. | Image.propTypes.source | No | iOS |
+| `minimumTrackImage` | Assigns a minimum track image. Only static images are supported. The rightmost pixel of the image will be stretched to fill the track. | Image.propTypes.source | No | iOS |
+| `thumbImage` | Sets an image for the thumb. Only static images are supported. Needs to be a URI of a local or network image; base64-encoded SVG is not supported. | Image.propTypes.source | No | |
+| `trackImage` | Assigns a single image for the track. Only static images are supported. The center pixel of the image will be stretched to fill the track. | Image.propTypes.source | No | iOS | |
+| `ref` | Reference object. | MutableRefObject | No | web |
+| `View` | [Inherited `View` props...](https://github.com/facebook/react-native-website/blob/master/docs/view.md#props) | | | |
 
-* [Inherited `View` props...](https://github.com/facebook/react-native-website/blob/master/docs/view.md#props)
-
-- [`style`](#style)
-- [`disabled`](#disabled)
-- [`maximumValue`](#maximumvalue)
-- [`minimumTrackTintColor`](#minimumtracktintcolor)
-- [`minimumValue`](#minimumvalue)
-- [`onSlidingStart`](#onslidingstart)
-- [`onSlidingComplete`](#onslidingcomplete)
-- [`onValueChange`](#onvaluechange)
-- [`step`](#step)
-- [`maximumTrackTintColor`](#maximumtracktintcolor)
-- [`testID`](#testid)
-- [`value`](#value)
-- [`inverted`](#inverted)
-- [`tapToSeek`](#tapToSeek)
-- [`vertical`](#vertical)
-- [`thumbTintColor`](#thumbtintcolor)
-- [`maximumTrackImage`](#maximumtrackimage)
-- [`minimumTrackImage`](#minimumtrackimage)
-- [`thumbImage`](#thumbimage)
-- [`trackImage`](#trackimage)
-- [`ref`](#ref)
-
----
-
-### `style`
-
-Used to style and layout the `Slider`. See `StyleSheet.js` and `ViewStylePropTypes.js` for more info.
-
-| Type       | Required |
-| ---------- | -------- |
-| View.style | No       |
-
----
-
-### `disabled`
-
-If true the user won't be able to move the slider. Default value is false.
-
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
-
----
-
-### `maximumValue`
-
-Initial maximum value of the slider. Default value is 1.
-
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
-
----
-
-### `minimumTrackTintColor`
-
-The color used for the track to the left of the button. Overrides the default blue gradient image on iOS.
-
-| Type               | Required |
-| ------------------ | -------- |
-| [color](https://reactnative.dev/docs/colors) | No       |
-
----
-
-### `minimumValue`
-
-Initial minimum value of the slider. Default value is 0.
-
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
-
----
-
-### `onSlidingStart`
-
-Callback that is called when the user picks up the slider. The initial value is passed as an argument to the callback handler.
-
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
-
----
-
-### `onSlidingComplete`
-
-Callback that is called when the user releases the slider, regardless if the value has changed. The current value is passed as an argument to the callback handler.
-
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
-
----
-
-### `onValueChange`
-
-Callback continuously called while the user is dragging the slider.
-
-| Type     | Required |
-| -------- | -------- |
-| function | No       |
-
----
-
-### `step`
-
-Step value of the slider. The value should be between 0 and (maximumValue - minimumValue). Default value is 0.
-
-On Windows OS the default value is 1% of slider's range (from `minimumValue` to `maximumValue`).
-
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
-
----
-
-### `maximumTrackTintColor`
-
-The color used for the track to the right of the button. Overrides the default gray gradient image on iOS.
-
-| Type               | Required |
-| ------------------ | -------- |
-| [color](https://reactnative.dev/docs/colors) | No       |
-
----
-
-### `testID`
-
-Used to locate this view in UI automation tests.
-
-| Type   | Required |
-| ------ | -------- |
-| string | No       |
-
----
-
-### `value`
-
-Initial value of the slider. The value should be between minimumValue and maximumValue, which default to 0 and 1 respectively. Default value is 0.
-
-_This is not a controlled component_, you don't need to update the value during dragging.
-
-| Type   | Required |
-| ------ | -------- |
-| number | No       |
-
----
-
-### `tapToSeek`
-Permits tapping on the slider track to set the thumb position. Defaults to false on iOS. No effect on Android or Windows.
-
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | iOS      |
-
----
-
-### `inverted`
-Reverses the direction of the slider. Default value is false.
-
-| Type | Required |
-| ---- | -------- |
-| bool | No       |
-
----
-
-### `vertical`
-Changes the orientation of the slider to vertical, if set to `true`. Default value is false.
-
-| Type | Required | Platform |
-| ---- | -------- | -------- |
-| bool | No       | Windows  |
-
----
-
-### `thumbTintColor`
-
-Color of the foreground switch grip.
-
-| Type               | Required | Platform |
-| ------------------ | -------- | -------- |
-| [color](https://reactnative.dev/docs/colors) | No       | Android  |
-
----
-
-### `maximumTrackImage`
-
-Assigns a maximum track image. Only static images are supported. The leftmost pixel of the image will be stretched to fill the track.
-
-| Type                   | Required | Platform |
-| ---------------------- | -------- | -------- |
-| Image.propTypes.source | No       | iOS      |
-
-### `minimumTrackImage`
-
-Assigns a minimum track image. Only static images are supported. The rightmost pixel of the image will be stretched to fill the track.
-
-| Type                   | Required | Platform |
-| ---------------------- | -------- | -------- |
-| Image.propTypes.source | No       | iOS      |
-
----
-
-### `thumbImage`
-
-Sets an image for the thumb. Only static images are supported. Needs to be a URI of a local or network image; base64-encoded SVG is not supported.
-
-
-| Type                   | Required | 
-| ---------------------- | -------- | 
-| Image.propTypes.source | No       | 
-
----
-
-### `trackImage`
-
-Assigns a single image for the track. Only static images are supported. The center pixel of the image will be stretched to fill the track.
-
-| Type                   | Required | Platform |
-| ---------------------- | -------- | -------- |
-| Image.propTypes.source | No       | iOS      |
-
----
-
-### `ref`
-
-Reference object.
-
-| Type             | Required | Platform |
-| ---------------- | -------- | -------- |
-| MutableRefObject | No       | web      |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -130,17 +130,17 @@ to run them all.
 
 When [creating an issue](https://github.com/callstack/react-native-slider/issues/new/choose) please remember to specify the platform which the issue occurs on.
 
-# Running the example app 
+## Running the example app 
 While developing, you can run the example app to test your changes.
 
-## Setup
+### Setup
 
 - Clone the repository 
 - Run `yarn` in the root directory to install dependencies, and again in `src` to create the dist build.
 - (on iOS) Run `npx pod-install` from the `example` directory
 - (on Windows) You need to manually link the Slider module to your project.
 
-## Start the app
+### Start the app
 
 - Run `yarn run:android` to run on Android
 - Run `yarn run:ios` to run on iOS
@@ -161,10 +161,6 @@ This module was extracted from `react-native` core. Please, refer to https://git
 
 ## Made with ❤️ at Callstack
 
-`@callstack/ReactNativeNotes` is an open source project and will always remain free to use. If you think it's cool, please star it 🌟. [Callstack](https://callstack.com/) is a group of React and React Native geeks, contact us at [hello@callstack.com](mailto:hello@callstack.com) if you need any help with these or just want to say hi!
+`@callstack/react-native-slider` is an open source project and will always remain free to use. If you think it's cool, please star it 🌟. [Callstack](https://callstack.com/) is a group of React and React Native geeks, contact us at [hello@callstack.com](mailto:hello@callstack.com) if you need any help with these or just want to say hi!
 
 Like the project? ⚛️ [Join the team](https://callstack.com/careers) who does amazing stuff for clients and drives React Native Open Source! 🔥
-
-
-## License
-The library is released under the MIT licence. For more information see `LICENSE`.

--- a/README.md
+++ b/README.md
@@ -77,30 +77,30 @@ import Slider from '@react-native-community/slider';
 ```
 
 
-### Properties
+## Properties
 
 | Property | Description | Type | Required | Platform |
 | -------- | ----------- | ---- | -------- | -------- |
 | `style` | Used to style and layout the `Slider`. See `StyleSheet.js` and `ViewStylePropTypes.js` for more info. | View.style | No | |
-| `disabled`| If true the user won't be able to move the slider. Default value is false. | bool | No | |
-| `maximumValue` | Initial maximum value of the slider. Default value is 1. | number | No | |
-| `minimumTrackTintColor` | The color used for the track to the left of the button. Overrides the default blue gradient image on iOS. | [color](https://reactnative.dev/docs/colors) | No | |
-| `minimumValue` | Initial minimum value of the slider. Default value is 0. | number | No | |
-| `onSlidingStart` | Callback that is called when the user picks up the slider. The initial value is passed as an argument to the callback handler. | function | No | |
-| `onSlidingComplete` | Callback that is called when the user releases the slider, regardless if the value has changed. The current value is passed as an argument to the callback handler. | function | No | |
+| `disabled`| If true the user won't be able to move the slider.<br/>Default value is false. | bool | No | |
+| `maximumValue` | Initial maximum value of the slider.<br/>Default value is 1. | number | No | |
+| `minimumTrackTintColor` | The color used for the track to the left of the button.<br/>Overrides the default blue gradient image on iOS. | [color](https://reactnative.dev/docs/colors) | No | |
+| `minimumValue` | Initial minimum value of the slider.<br/>Default value is 0. | number | No | |
+| `onSlidingStart` | Callback that is called when the user picks up the slider.<br/>The initial value is passed as an argument to the callback handler. | function | No | |
+| `onSlidingComplete` | Callback that is called when the user releases the slider, regardless if the value has changed.<br/>The current value is passed as an argument to the callback handler. | function | No | |
 | `onValueChange` | Callback continuously called while the user is dragging the slider. | function | No | |
-| `step` | Step value of the slider. The value should be between 0 and (maximumValue - minimumValue). Default value is 0. On Windows OS the default value is 1% of slider's range (from `minimumValue` to `maximumValue`). | number | No | |
-| `maximumTrackTintColor` | The color used for the track to the right of the button. Overrides the default gray gradient image on iOS. | [color](https://reactnative.dev/docs/colors) | No | |
+| `step` | Step value of the slider. The value should be between 0 and (maximumValue - minimumValue). Default value is 0.<br/>On Windows OS the default value is 1% of slider's range (from `minimumValue` to `maximumValue`). | number | No | |
+| `maximumTrackTintColor` | The color used for the track to the right of the button.<br/>Overrides the default gray gradient image on iOS. | [color](https://reactnative.dev/docs/colors) | No | |
 | `testID` | Used to locate this view in UI automation tests. | string | No | |
 | `value` | Initial value of the slider. The value should be between minimumValue and maximumValue, which default to 0 and 1 respectively. Default value is 0.<br/>_This is not a controlled component_, you don't need to update the value during dragging. | number | No | |
-| `tapToSeek` | Permits tapping on the slider track to set the thumb position. Defaults to false on iOS. No effect on Android or Windows. | bool | No | iOS |
-| `inverted` | Reverses the direction of the slider. Default value is false. | bool | No | |
-| `vertical` | Changes the orientation of the slider to vertical, if set to `true`. Default value is false. | bool | No | Windows |
+| `tapToSeek` | Permits tapping on the slider track to set the thumb position.<br/>Defaults to false on iOS. No effect on Android or Windows. | bool | No | iOS |
+| `inverted` | Reverses the direction of the slider.<br/>Default value is false. | bool | No | |
+| `vertical` | Changes the orientation of the slider to vertical, if set to `true`.<br/>Default value is false. | bool | No | Windows |
 | `thumbTintColor` | Color of the foreground switch grip. | [color](https://reactnative.dev/docs/colors) | No | Android |
-| `maximumTrackImage` | Assigns a maximum track image. Only static images are supported. The leftmost pixel of the image will be stretched to fill the track. | Image.propTypes.source | No | iOS |
-| `minimumTrackImage` | Assigns a minimum track image. Only static images are supported. The rightmost pixel of the image will be stretched to fill the track. | Image.propTypes.source | No | iOS |
-| `thumbImage` | Sets an image for the thumb. Only static images are supported. Needs to be a URI of a local or network image; base64-encoded SVG is not supported. | Image.propTypes.source | No | |
-| `trackImage` | Assigns a single image for the track. Only static images are supported. The center pixel of the image will be stretched to fill the track. | Image.propTypes.source | No | iOS | |
+| `maximumTrackImage` | Assigns a maximum track image. Only static images are supported. The leftmost pixel of the image will be stretched to fill the track. | Image<br/>.propTypes<br/>.source | No | iOS |
+| `minimumTrackImage` | Assigns a minimum track image. Only static images are supported. The rightmost pixel of the image will be stretched to fill the track. | Image<br/>.propTypes<br/>.source | No | iOS |
+| `thumbImage` | Sets an image for the thumb. Only static images are supported. Needs to be a URI of a local or network image; base64-encoded SVG is not supported. | Image<br/>.propTypes<br/>.source | No | |
+| `trackImage` | Assigns a single image for the track. Only static images are supported. The center pixel of the image will be stretched to fill the track. | Image<br/>.propTypes<br/>.source | No | iOS | |
 | `ref` | Reference object. | MutableRefObject | No | web |
 | `View` | [Inherited `View` props...](https://github.com/facebook/react-native-website/blob/master/docs/view.md#props) | | | |
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ yarn test
 to run them all.
 * Remember to cover your changes with tests if possible.
 
+When [creating an issue](https://github.com/callstack/react-native-slider/issues/new/choose) please remember to specify the platform which the issue occurs on.
+
 # Running the example app 
 While developing, you can run the example app to test your changes.
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,166 @@
+<p align="center">
+  <h1 align="center"> <code>@react-native-community/slider</code> </h1>
+</p>
+<p align="center">
+    <a href="https://www.npmjs.com/package/@react-native-community/slider">
+        <img src="https://img.shields.io/npm/v/@react-native-community/slider.svg" alt="Latest version released on npmjs" />
+    </a>
+    <a href="https://app.circleci.com/pipelines/github/callstack/react-native-slider?branch=master">
+        <img src="https://img.shields.io/circleci/project/github/callstack/react-native-slider/master.svg" alt="Build on CircleCI" />
+    </a>
+    <a href="https://github.com/callstack/react-native-slider">
+        <img src="https://img.shields.io/badge/platforms-android%20|%20ios%20|%20windows%20|%20web-lightgrey.svg" alt="Supported platforms" />
+    </a>
+    <a href="https://github.com/callstack/react-native-slider/blob/master/LICENSE.md">
+        <img src="https://img.shields.io/npm/l/@react-native-community/slider.svg" alt="License" />
+    </a>
+</p>
+<p align="center">
+  React Native component used to select a single value from a range of values.
+  <br>Currently supported on following platforms:
+</p>
+
+|iOS|Android|Windows|
+|:-:|:-:|:-:|
+|![iOS Screenshot](https://i.postimg.cc/dQTYzGD5/Screenshot-2019-03-25-at-11-24-59.png)|![Android Screenshot](https://i.postimg.cc/CKdtbVqc/Screenshot-2019-03-25-at-11-26-54.png)|![Windows Screenshot](example/sliderWindows.JPG)|
+
+## Installation & Usage
+
+To install this module `cd` to your project directory and enter the following command:
+```
+yarn add @react-native-community/slider
+```
+or
+```
+npm install @react-native-community/slider --save
+```
+If using iOS please remember to install cocoapods by running: `npx pod-install`
+<br/>For web support please use `@react-native-community/slider@next`
+
+The following code presents the basic usage scenario of this library:
+```javascript
+import Slider from '@react-native-community/slider';
+
+<Slider
+  style={{width: 200, height: 40}}
+  minimumValue={0}
+  maximumValue={1}
+  minimumTrackTintColor="#FFFFFF"
+  maximumTrackTintColor="#000000"
+/>
+```
+
+Check out the [example project](example) for more examples.
+
+---
+
+**Migrating from the core `react-native` module**
+
+This module was created when the Slider was split out from the core of React Native.
+<br/>To migrate to this module you need to follow the installation instructions above and then change you imports from:
+
+```javascript
+import { Slider } from 'react-native';
+```
+
+to:
+
+```javascript
+import Slider from '@react-native-community/slider';
+```
+
+## React Native Compatibility
+To use this library you need to ensure you are using the correct version of React Native.
+
+| `@react-native-community/slider` version | Required React Native Version |
+| ---------------------------------------- | ----------------------------- |
+| `4.x.x`                                  | `>=0.60`; `>=0.62` (on Windows);  |
+| `3.1.x`                                  | `>=0.60`                      |
+| `2.x.x`                                  | `>= 0.60`                     |
+| [`1.x.x`](https://github.com/react-native-community/react-native-slider/tree/937f0942f1fffc6ed88b5cf7c88d73b7878f00f0)  | `<= 0.59` |
+
+
+## Properties
+
+| Property | Description | Type | Required | Platform |
+| -------- | ----------- | ---- | -------- | -------- |
+| `style` | Used to style and layout the `Slider`. See `StyleSheet.js` and `ViewStylePropTypes.js` for more info. | View.style | No | |
+| `disabled`| If true the user won't be able to move the slider.<br/>Default value is false. | bool | No | |
+| `maximumValue` | Initial maximum value of the slider.<br/>Default value is 1. | number | No | |
+| `minimumTrackTintColor` | The color used for the track to the left of the button.<br/>Overrides the default blue gradient image on iOS. | [color](https://reactnative.dev/docs/colors) | No | |
+| `minimumValue` | Initial minimum value of the slider.<br/>Default value is 0. | number | No | |
+| `onSlidingStart` | Callback that is called when the user picks up the slider.<br/>The initial value is passed as an argument to the callback handler. | function | No | |
+| `onSlidingComplete` | Callback that is called when the user releases the slider, regardless if the value has changed.<br/>The current value is passed as an argument to the callback handler. | function | No | |
+| `onValueChange` | Callback continuously called while the user is dragging the slider. | function | No | |
+| `step` | Step value of the slider. The value should be between 0 and (maximumValue - minimumValue). Default value is 0.<br/>On Windows OS the default value is 1% of slider's range (from `minimumValue` to `maximumValue`). | number | No | |
+| `maximumTrackTintColor` | The color used for the track to the right of the button.<br/>Overrides the default gray gradient image on iOS. | [color](https://reactnative.dev/docs/colors) | No | |
+| `testID` | Used to locate this view in UI automation tests. | string | No | |
+| `value` | Initial value of the slider. The value should be between minimumValue and maximumValue, which default to 0 and 1 respectively. Default value is 0.<br/>_This is not a controlled component_, you don't need to update the value during dragging. | number | No | |
+| `tapToSeek` | Permits tapping on the slider track to set the thumb position.<br/>Defaults to false on iOS. No effect on Android or Windows. | bool | No | iOS |
+| `inverted` | Reverses the direction of the slider.<br/>Default value is false. | bool | No | |
+| `vertical` | Changes the orientation of the slider to vertical, if set to `true`.<br/>Default value is false. | bool | No | Windows |
+| `thumbTintColor` | Color of the foreground switch grip. | [color](https://reactnative.dev/docs/colors) | No | Android |
+| `maximumTrackImage` | Assigns a maximum track image. Only static images are supported. The leftmost pixel of the image will be stretched to fill the track. | Image<br/>.propTypes<br/>.source | No | iOS |
+| `minimumTrackImage` | Assigns a minimum track image. Only static images are supported. The rightmost pixel of the image will be stretched to fill the track. | Image<br/>.propTypes<br/>.source | No | iOS |
+| `thumbImage` | Sets an image for the thumb. Only static images are supported. Needs to be a URI of a local or network image; base64-encoded SVG is not supported. | Image<br/>.propTypes<br/>.source | No | |
+| `trackImage` | Assigns a single image for the track. Only static images are supported. The center pixel of the image will be stretched to fill the track. | Image<br/>.propTypes<br/>.source | No | iOS | |
+| `ref` | Reference object. | MutableRefObject | No | web |
+| `View` | [Inherited `View` props...](https://github.com/facebook/react-native-website/blob/master/docs/view.md#props) | | | |
+
+
+## Contributing
+
+This project uses [yarn workspaces](https://classic.yarnpkg.com/en/docs/workspaces/) to handle its internal dependencies.
+* Make sure to use `yarn` to install dependencies when implementing changes to this library.
+```sh
+yarn install
+```
+* Make sure your code passes Flow, ESLint and the tests. Run the following to verify:
+```sh
+yarn validate:flow
+yarn validate:eslint --fix
+yarn test:jest
+```
+or 
+```sh
+yarn test
+```
+to run them all.
+* Remember to cover your changes with tests if possible.
+
+When [creating an issue](https://github.com/callstack/react-native-slider/issues/new/choose) please remember to specify the platform which the issue occurs on.
+
+## Running the example app 
+While developing, you can run the example app to test your changes.
+
+### Setup
+
+- Clone the repository 
+- Run `yarn` in the root directory to install dependencies, and again in `src` to create the dist build.
+- (on iOS) Run `npx pod-install` from the `example` directory
+- (on Windows) You need to manually link the Slider module to your project.
+
+### Start the app
+
+- Run `yarn run:android` to run on Android
+- Run `yarn run:ios` to run on iOS
+- Run `yarn run:web` to run on web
+- Run `yarn run:windows` to run on Windows.
+
+
+## Maintainers
+
+- [Michał Chudziak](https://github.com/michalchudziak) - [Callstack](https://callstack.com/)
+- [Bartosz Klonowski](https://github.com/BartoszKlonowski) - [Callstack](https://callstack.com/)
+
+## Contributors
+
+This module was extracted from `react-native` core. Please, refer to [contributors graph](https://github.com/react-native-community/react-native-slider/graphs/contributors) for the complete list of contributors.
+
+---
+
+## Made with ❤️ at Callstack
+
+`@callstack/react-native-slider` is an open source project and will always remain free to use. If you think it's cool, please star it 🌟. [Callstack](https://callstack.com/) is a group of React and React Native geeks, contact us at [hello@callstack.com](mailto:hello@callstack.com) if you need any help with these or just want to say hi!
+
+Like the project? ⚛️ [Join the team](https://callstack.com/careers) who does amazing stuff for clients and drives React Native Open Source! 🔥

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/slider",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "license": "MIT",
   "author": "react-native-community",
   "homepage": "https://github.com/react-native-community/react-native-slider",


### PR DESCRIPTION
This pull request updates in general the README.
The improvements and changes are:
* Layout improved
* Badges fixed and updated
* Properties presented in more compressed but readable way
(table instead of separate sections)
* Unified example of usage with combined information about other platforms
* Links updated
* Footer of Callstack used

To check this README document go to [feature/readme-update](https://github.com/callstack/react-native-slider/blob/feature/readme-update/README.md) branch and check the README.

---

**NOTE:** this pull request also adds the README to the *src/* directory which is published in the npm.
This way it will also be displayed on the npm site (currently it is completely empty which looks sad and abandoned).

There's also the version bumped to the latest at the time of publishing this change - v4.1.2

---

For more information please check the commit and their messages.