### PR TITLE
Fix: Remove redundant React, Rreact Native & React Native Windows from `devDependencies`

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -36,9 +36,6 @@
     "flow-bin": "0.113.0",
     "jest": "^24.9.0",
     "metro-react-native-babel-preset": "^0.56.0",
-    "react": "^16.11.0",
-    "react-native": "^0.62.3",
-    "react-native-windows": "^0.62.0-0",
     "react-test-renderer": "16.9.0"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7199,25 +7199,6 @@ react-native-windows@^0.62.0:
     uuid "^3.3.2"
     xml-parser "^1.2.1"
 
-react-native-windows@^0.62.0-0:
-  version "0.62.2"
-  resolved "https://registry.yarnpkg.com/react-native-windows/-/react-native-windows-0.62.2.tgz#eae6d9e55116d69c8d8316ec6e52505c760ba1bd"
-  integrity sha512-ZsPxhJrzkBjzLmt9xzAwos1iTykAsyIij2P6radH2eZJmMYJ2sqQwRAsNcjk9OKNM0zj3T4lyCN3879gRZ6yMg==
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    cli-spinners "^2.2.0"
-    create-react-class "^15.6.3"
-    envinfo "^7.5.0"
-    fbjs "^1.0.0"
-    glob "^7.1.1"
-    ora "^3.4.0"
-    prop-types "^15.7.2"
-    regenerator-runtime "^0.13.2"
-    shelljs "^0.7.8"
-    username "^5.1.0"
-    uuid "^3.3.2"
-    xml-parser "^1.2.1"
-
 react-native@^0.62.3:
   version "0.62.3"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.62.3.tgz#9a2e96af3dedd0723c8657831eec4ed3c30f3299"


### PR DESCRIPTION
This pull request fixes #307 

It removes the React, React Native and React Native Windows from `devDependencies` when it comes to *src/package.json* - package dependencies.

The reason that these can be safely removed is that these libraries are also listed in the `peerDependencies` which makes them still being checked when installing.
Both workspaces should not be affected as *src/* should use the packages provided by the consumer, while *example/* should satisfy `peerDependencies` by having them installed in the example app
(moreover: *example* is about to change in upcoming deliveries).

