### PR TITLE
Fix: `peerDependencies` should require bigger or equal versions

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/slider",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "license": "MIT",
   "author": "react-native-community",
   "homepage": "https://github.com/react-native-community/react-native-slider",
@@ -19,9 +19,9 @@
     "prepare": "babel --out-dir dist js"
   },
   "peerDependencies": {
-    "react": "^16.11.0",
-    "react-native": "^0.62.3",
-    "react-native-windows": "^0.62.0"
+    "react": ">=16.11.0",
+    "react-native": ">=0.62.3",
+    "react-native-windows": ">=0.62.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
This pull request is a quick followup of #308 
It specifies the `peerDependencies` to use major versions bigger or equal to the specified in *src/package.json*.