### PR TITLE
Use mavenCentral instead of jscenter for Android example app

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -33,6 +33,6 @@ allprojects {
 
         google()
         jcenter()
-        maven { url 'https://jitpack.io' }
+        maven { url 'https://www.jitpack.io' }
     }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:4.1.0")
@@ -32,7 +32,10 @@ allprojects {
         }
 
         google()
-        jcenter()
-        maven { url 'https://www.jitpack.io' }
+        mavenCentral()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }


### PR DESCRIPTION
This pull request fixes the build error of Android Example app:
```
> Could not resolve all artifacts for configuration ':app:debugRuntimeClasspath'.
   > Could not resolve org.webkit:android-jsc:+.
     Required by:
         project :app
      > Failed to list versions for org.webkit:android-jsc.
         > Unable to load Maven meta-data from https://jcenter.bintray.com/org/webkit/android-jsc/maven-metadata.xml.
            > Could not get resource 'https://jcenter.bintray.com/org/webkit/android-jsc/maven-metadata.xml'.
               > Could not GET 'https://jcenter.bintray.com/org/webkit/android-jsc/maven-metadata.xml'.
                  > Read timed out
```
and others.

This pull request is related to [JCenter Serive update](https://developer.android.com/studio/build/jcenter-migration) announcement.