### PR TITLE
Update the Examples in package's README

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -22,7 +22,7 @@
 
 |iOS|Android|Windows|
 |:-:|:-:|:-:|
-|![iOS Screenshot](https://i.postimg.cc/dQTYzGD5/Screenshot-2019-03-25-at-11-24-59.png)|![Android Screenshot](https://i.postimg.cc/CKdtbVqc/Screenshot-2019-03-25-at-11-26-54.png)|![Windows Screenshot](example/sliderWindows.JPG)|
+|![iOS Screenshot](https://raw.githubusercontent.com/callstack/react-native-slider/master/.github/Examples/Slider-iOS-Example.gif)|![Android Screenshot](https://raw.githubusercontent.com/callstack/react-native-slider/master/.github/Examples/Slider-Android-Example.gif)|![Windows Screenshot](https://raw.githubusercontent.com/callstack/react-native-slider/master/.github/Examples/Slider-Windows-Example.gif)|
 
 ## Installation & Usage
 


### PR DESCRIPTION
The examples animations are now also given to the npm.js package's README.
The way to do that is to point to exact image (.gif) in the blob of master.

The only drawback of that is that it's going to be outdated once the examples change their place in the repository.

---

To test please visit the [README](https://github.com/callstack/react-native-slider/tree/fix/examples-in-package-readme/src#readme) of package in this branch.