### PR TITLE
ISSUE-319-Accessibility not working perfectly in Android 11 devices 

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext {
         buildToolsVersion = "29.0.3"
         minSdkVersion = 21
-        compileSdkVersion = 29
+        compileSdkVersion = 30
         targetSdkVersion = 29
     }
     repositories {

--- a/src/android/gradle.properties
+++ b/src/android/gradle.properties
@@ -1,4 +1,4 @@
-ReactNativeSlider_compileSdkVersion=28
+ReactNativeSlider_compileSdkVersion=30
 ReactNativeSlider_buildToolsVersion=28.0.3
 ReactNativeSlider_targetSdkVersion=27
 ReactNativeSlider_minSdkVersion=16

--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -60,9 +60,9 @@ public class ReactSlider extends AppCompatSeekBar {
 
   private double mStepCalculated = 0;
 
-  public String mAccessibilityUnits;
+  private String mAccessibilityUnits;
 
-  public List<String> mAccessibilityIncrements;
+  private List<String> mAccessibilityIncrements;
 
   public ReactSlider(Context context, @Nullable AttributeSet attrs, int style) {
     super(context, attrs, style);
@@ -111,7 +111,7 @@ public class ReactSlider extends AppCompatSeekBar {
     super.onPopulateAccessibilityEvent(event);
     if (event.getEventType() == AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED ||
         (event.getEventType() == AccessibilityEvent.TYPE_VIEW_SELECTED && this.isAccessibilityFocused())) {
-      this.setupAccessibility();
+      this.setupAccessibility((int) mValue);
     }
   }
 
@@ -139,9 +139,8 @@ public class ReactSlider extends AppCompatSeekBar {
     }
   }
 
-  private void setupAccessibility() {
+  public void setupAccessibility(int index) {
     if (mAccessibilityUnits != null && mAccessibilityIncrements != null && mAccessibilityIncrements.size() - 1 == (int)mMaxValue) {
-      int index = (int)mValue;
       String sliderValue = mAccessibilityIncrements.get(index);
       int stringLength = mAccessibilityUnits.length();
 

--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -139,7 +139,7 @@ public class ReactSlider extends AppCompatSeekBar {
     }
   }
 
-  public void setupAccessibility() {
+  private void setupAccessibility() {
     if (mAccessibilityUnits != null && mAccessibilityIncrements != null && mAccessibilityIncrements.size() - 1 == (int)mMaxValue) {
       int index = (int)mValue;
       String sliderValue = mAccessibilityIncrements.get(index);

--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -60,9 +60,9 @@ public class ReactSlider extends AppCompatSeekBar {
 
   private double mStepCalculated = 0;
 
-  private String mAccessibilityUnits;
+  public String mAccessibilityUnits;
 
-  private List<String> mAccessibilityIncrements;
+  public List<String> mAccessibilityIncrements;
 
   public ReactSlider(Context context, @Nullable AttributeSet attrs, int style) {
     super(context, attrs, style);
@@ -139,7 +139,7 @@ public class ReactSlider extends AppCompatSeekBar {
     }
   }
 
-  private void setupAccessibility() {
+  public void setupAccessibility() {
     if (mAccessibilityUnits != null && mAccessibilityIncrements != null && mAccessibilityIncrements.size() - 1 == (int)mMaxValue) {
       int index = (int)mValue;
       String sliderValue = mAccessibilityIncrements.get(index);

--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -152,7 +152,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
     if (view.isAccessibilityFocused() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
       int index = (int)value;
       view.setupAccessibility(index);
-    }  
+    }
   }
 
   @ReactProp(name = "minimumValue", defaultDouble = 0d)

--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -151,13 +151,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
     view.setOnSeekBarChangeListener(ON_CHANGE_LISTENER);
     if (view.isAccessibilityFocused() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
       int index = (int)value;
-      String sliderValue = view.mAccessibilityIncrements.get(index);
-      int stringLength = view.mAccessibilityUnits.length();
-      String spokenUnits = view.mAccessibilityUnits;
-      if (sliderValue != null && Integer.parseInt(sliderValue) == 1) {
-        spokenUnits = spokenUnits.substring(0, stringLength - 1);
-      }
-      view.announceForAccessibility(String.format("%s %s", sliderValue, spokenUnits));
+      view.setupAccessibility(index);
     }  
   }
 

--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -149,18 +149,16 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
     view.setOnSeekBarChangeListener(null);
     view.setValue(value);
     view.setOnSeekBarChangeListener(ON_CHANGE_LISTENER);
-    if (view.isAccessibilityFocused()) {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        int index = (int)value;
-        String sliderValue = view.mAccessibilityIncrements.get(index);
-        int stringLength = view.mAccessibilityUnits.length();
-        String spokenUnits = view.mAccessibilityUnits;
-        if (sliderValue != null && Integer.parseInt(sliderValue) == 1) {
-          spokenUnits = spokenUnits.substring(0, stringLength - 1);
-        }
-        view.announceForAccessibility(String.format("%s %s", sliderValue, spokenUnits));
+    if (view.isAccessibilityFocused() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      int index = (int)value;
+      String sliderValue = view.mAccessibilityIncrements.get(index);
+      int stringLength = view.mAccessibilityUnits.length();
+      String spokenUnits = view.mAccessibilityUnits;
+      if (sliderValue != null && Integer.parseInt(sliderValue) == 1) {
+        spokenUnits = spokenUnits.substring(0, stringLength - 1);
       }
-    }
+      view.announceForAccessibility(String.format("%s %s", sliderValue, spokenUnits));
+    }  
   }
 
   @ReactProp(name = "minimumValue", defaultDouble = 0d)

--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -149,6 +149,18 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
     view.setOnSeekBarChangeListener(null);
     view.setValue(value);
     view.setOnSeekBarChangeListener(ON_CHANGE_LISTENER);
+    if (view.isAccessibilityFocused()) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        int index = (int)value;
+        String sliderValue = view.mAccessibilityIncrements.get(index);
+        int stringLength = view.mAccessibilityUnits.length();
+        String spokenUnits = view.mAccessibilityUnits;
+        if (sliderValue != null && Integer.parseInt(sliderValue) == 1) {
+          spokenUnits = spokenUnits.substring(0, stringLength - 1);
+        }
+        view.announceForAccessibility(String.format("%s %s", sliderValue, spokenUnits));
+      }
+    }
   }
 
   @ReactProp(name = "minimumValue", defaultDouble = 0d)


### PR DESCRIPTION
Summary:
---------

- For Android 11.0 devices, while sliding we are only hearing the percentage of the slider but not `accessibilityIncrements` and `accessibilityUnits`. It is working fine for the other versions below Android 11.
- As part of this PR we are fixing this issue in Android 11 devices.
- I have tested this in various android versions(Android 9, Android 10, Android 11) devices with this fix, it is working perfectly now.
### Before - Android version 11:
https://drive.google.com/file/d/1mfqT6bfyoVfSETyN89gtEo3golnJKiId/view?usp=sharing

### After  - Android version 11:
https://drive.google.com/file/d/1ADx0VLZxxtxni-_MozDAyNBLu2cS_HwJ/view?usp=sharing

### After - Android version 10:
https://drive.google.com/file/d/1nL1e9410y6pdMmjFUXuImYJWqz8Xqrbl/view?usp=sharing

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

- Changes were tested manually in different Android versions of devices.

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->