### PR TITLE
Update the `compileSdkVersion` for both lib and example

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext {
         buildToolsVersion = "29.0.3"
         minSdkVersion = 21
-        compileSdkVersion = 29
+        compileSdkVersion = 30
         targetSdkVersion = 29
     }
     repositories {

--- a/src/android/gradle.properties
+++ b/src/android/gradle.properties
@@ -1,4 +1,4 @@
-ReactNativeSlider_compileSdkVersion=28
+ReactNativeSlider_compileSdkVersion=30
 ReactNativeSlider_buildToolsVersion=28.0.3
 ReactNativeSlider_targetSdkVersion=27
 ReactNativeSlider_minSdkVersion=16


### PR DESCRIPTION
This pull request updates the `compileSdkVersion` from 28 and 29 to 30, so that the API level 30 can be safely used in further implementation.
This is also related to #323 where such changes are required for the CI to pass.