### PR TITLE
Fix: Crash when using maximum & minimum `trackTintColor`

### DIFF
--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -7,6 +7,7 @@
 
 package com.reactnativecommunity.slider;
 
+import android.graphics.PorterDuffColorFilter;
 import android.os.Build;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
@@ -187,7 +188,12 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
     if (color == null) {
       progress.clearColorFilter();
     } else {
-      progress.setColorFilter(color, PorterDuff.Mode.SRC_IN);
+      if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
+        progress.setColorFilter(new PorterDuffColorFilter((int)color, PorterDuff.Mode.SRC_IN));
+      }
+      else {
+        progress.setColorFilter(color, PorterDuff.Mode.SRC_IN);
+      }
     }
   }
 
@@ -207,7 +213,12 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
     if (color == null) {
       background.clearColorFilter();
     } else {
-      background.setColorFilter(color, PorterDuff.Mode.SRC_IN);
+      if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
+        background.setColorFilter(new PorterDuffColorFilter((int)color, PorterDuff.Mode.SRC_IN));
+      }
+      else {
+        background.setColorFilter(color, PorterDuff.Mode.SRC_IN);
+      }
     }
   }
 


### PR DESCRIPTION
This pull request fixes #161.
The fix is to avoid using the deprecated API of `Drawable.setColorFilter`.

The replacement used in this implementation is to:
* check if version later than P(28) is used
* use current [setColorFilter](https://developer.android.com/reference/android/graphics/drawable/Drawable#setColorFilter(android.graphics.ColorFilter))
* use depracated one if previous version is used
(backward compatibility provided)

The fix was tested using the example application with the properties used in repro from an issue.