### PR TITLE
Fix: can't drag to the end of track on iOS

### DIFF
--- a/src/ios/RNCSliderManager.m
+++ b/src/ios/RNCSliderManager.m
@@ -77,9 +77,12 @@ RCT_EXPORT_MODULE()
 }
 
 static float discreteValue(RNCSlider *sender, float value) {
+  if (sender.step > 0 && value >= sender.maximumValue) {
+    return sender.maximumValue
+  }
+
   // If step is set and less than or equal to difference between max and min values,
   // pick the closest discrete multiple of step to return.
-
   if (sender.step > 0 && sender.step <= (sender.maximumValue - sender.minimumValue)) {
     
     // Round up when increase, round down when decrease.


### PR DESCRIPTION
This pull request fixes #191 

It checks whether the thumb should reach the maximum value and if yes, it moves it toward the end of track.
It was tested if this not affects the thumb when currently on maximum value.