### PR TITLE
Slider should announce disabled when interacting with

### DIFF
--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -147,7 +147,7 @@ public class ReactSlider extends AppCompatSeekBar {
   public boolean onTouchEvent(MotionEvent arg0) {
     super.onTouchEvent(arg0);
 
-    if (arg0.getActionMasked() == MotionEvent.ACTION_POINTER_DOWN && this.isEnabled() == false) {
+    if (arg0.getActionMasked() == MotionEvent.ACTION_DOWN && this.isEnabled() == false) {
       announceForAccessibility("slider disabled");
     }
     // Returns: True if the view handled the hover event


### PR DESCRIPTION
This pull request closes #265 
It delivers the overridden `onTouchEvent` which announce the *"disabled"* state of the Slider if a blind user tries to interact with disabled component.

---

The implementation is simple:
Override the [`onTouchEvent`](https://developer.android.com/reference/android/view/View#onTouchEvent(android.view.MotionEvent)) and check if Slider is already disabled **and** if the [`ACTION_DOWN`](https://developer.android.com/reference/android/view/MotionEvent#ACTION_DOWN) was performed on the Slider.
If both conditions are met send the accessibility message saying that "*slider disabled*" so that user knows that:
* he reached/touched or tried to interact with a Slider component
* the component is disabled

It's necessary to react only on the `ACTION_DOWN` event, omitting the `ACTION_UP`, to avoid spamming blind user with too many messages and because a Slider is not a button, and user will most probably try to drag it instead of clicking on it.
We allow the `taptoSeek` but it will still fall into the `ACTION_DOWN` category.

**NOTE:**
There's no `PerformClick()` override, even though the docs suggests to do it. The reason for not implementing it is that there cannot be a click event's reaction on a disabled component, and if it's enabled there's still the `onValueChange` which will announce the new `value` and `units`.
