### PR TITLE
Remove react-native-windows from `peerDependencies`

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -20,8 +20,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*",
-    "react-native-windows": "*"
+    "react-native": "*"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
This pull request fixes #333 

It removes the *react-native-windows* from `peerDependencies`.
It turns out that if installing this package for an application with react-native, the react-native-windows being required is not always met. And it doesn't have to be met, so requiring this package for every case can lead to conflicts.

**NOTE:** removing this from `peerDependencies` is still safe, because when using this app for Windows development, the react-native-windows has to be installed in the first place, so there's no benefit or requirement from having this library specified.
