### PR TITLE
Remove redundant *flow-bin* dependency

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -36,9 +36,6 @@ module.system.node.resolve_dirname=node_modules
 module.system.node.resolve_dirname=src
 emoji=true
 
-esproposal.optional_chaining=enable
-esproposal.nullish_coalescing=enable
-
 module.file_ext=.js
 module.file_ext=.json
 module.file_ext=.ios.js
@@ -53,10 +50,6 @@ suppress_type=$FlowFixMe
 suppress_type=$FlowFixMeProps
 suppress_type=$FlowFixMeState
 
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)?:? #[0-9]+
-suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
-
 [lints]
 sketchy-null-number=warn
 sketchy-null-mixed=warn
@@ -65,7 +58,6 @@ untyped-type-import=warn
 nonstrict-import=warn
 deprecated-type=warn
 unsafe-getters-setters=warn
-inexact-spread=warn
 unnecessary-invariant=warn
 signature-verification-failure=warn
 deprecated-utility=error
@@ -80,4 +72,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.113.0
+^0.163.0

--- a/src/package.json
+++ b/src/package.json
@@ -31,7 +31,6 @@
     "babel-jest": "^24.9.0",
     "babel-plugin-module-resolver": "3.1.3",
     "eslint": "^6.5.1",
-    "flow-bin": "0.113.0",
     "jest": "^24.9.0",
     "metro-react-native-babel-preset": "^0.56.0",
     "react-test-renderer": "16.9.0"
@@ -40,7 +39,5 @@
     "type": "git",
     "url": "https://github.com/callstack/react-native-slider.git"
   },
-  "dependencies": {
-    "flow-bin": "0.113.0"
-  }
+  "dependencies": {}
 }

--- a/src/package.json
+++ b/src/package.json
@@ -31,6 +31,7 @@
     "babel-jest": "^24.9.0",
     "babel-plugin-module-resolver": "3.1.3",
     "eslint": "^6.5.1",
+    "flow-bin": "^0.163.0",
     "jest": "^24.9.0",
     "metro-react-native-babel-preset": "^0.56.0",
     "react-test-renderer": "16.9.0"
@@ -38,6 +39,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/callstack/react-native-slider.git"
-  },
-  "dependencies": {}
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2197,8 +2197,6 @@
 
 "@react-native-community/slider@file:src":
   version "4.1.11"
-  dependencies:
-    flow-bin "0.113.0"
 
 "@react-native-windows/cli@0.65.0":
   version "0.65.0"
@@ -4498,11 +4496,6 @@ flatted@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
-
-flow-bin@0.113.0:
-  version "0.113.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.113.0.tgz#6457d250dbc6f71ca51e75f00a96d23cde5d987a"
-  integrity sha512-76uE2LGNe50wm+Jup8Np4FBcMbyy5V2iE+K25PPIYLaEMGHrL1jnQfP9L0hTzA5oh2ZJlexRLMlaPqIYIKH9nw==
 
 flow-parser@0.*:
   version "0.159.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4497,6 +4497,11 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
+flow-bin@^0.163.0:
+  version "0.163.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.163.0.tgz#c2cb62e336cfdeac035a4cc86e143e1e5ff4d1d0"
+  integrity sha512-4rNdO/lT38/c+8SR4eZK+PthE9c3MFiDnr8TYBpIM77EkM2yl9Ug8N2oPPk0UJs6kG93Yb61G14s95dfSoUARA==
+
 flow-parser@0.*:
   version "0.159.0"
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.159.0.tgz#478cb540be9f4ae2214c4f3c22430f3365b5da21"


### PR DESCRIPTION
This pull request fixes #340
It completely removes the *flow-bin* from dependencies mistakenly added along with Windows support.

---

The *flow-bin* is also required as a dev dependency, but it's there updated to the latest version: 0.163.0.
This update required some adjustments to be made to the *.flowconfig* so that it works as expected still.
