### PR TITLE
`value` property implemented as a controlled value

### DIFF
--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -56,6 +56,8 @@ public class ReactSlider extends AppCompatSeekBar {
    */
   private double mValue = 0;
 
+  private boolean isSliding = false;
+
   /** If zero it's determined automatically. */
   private double mStep = 0;
 
@@ -97,6 +99,14 @@ public class ReactSlider extends AppCompatSeekBar {
   /* package */ void setStep(double step) {
     mStep = step;
     updateAll();
+  }
+
+  boolean isSliding() {
+    return isSliding;
+  }
+
+  void isSliding(boolean isSliding) {
+    this.isSliding = isSliding;
   }
 
   void setAccessibilityUnits(String accessibilityUnits) {

--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -35,8 +35,6 @@ import javax.annotation.Nullable;
 
 /**
  * Manages instances of {@code ReactSlider}.
- *
- * Note that the slider is _not_ a controlled component.
  */
 public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
 
@@ -87,8 +85,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
           reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
               new ReactSliderEvent(
                   seekbar.getId(),
-                  ((ReactSlider) seekbar).toRealProgress(progress),
-                  fromUser));
+                  ((ReactSlider)seekbar).toRealProgress(progress), fromUser));
         }
 
         @Override
@@ -98,7 +95,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
           reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
               new ReactSlidingStartEvent(
                   seekbar.getId(),
-                  ((ReactSlider) seekbar).toRealProgress(seekbar.getProgress())));
+                  ((ReactSlider)seekbar).toRealProgress(seekbar.getProgress())));
         }
 
         @Override
@@ -108,7 +105,11 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
           reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
               new ReactSlidingCompleteEvent(
                   seekbar.getId(),
-                  ((ReactSlider) seekbar).toRealProgress(seekbar.getProgress())));
+                  ((ReactSlider)seekbar).toRealProgress(seekbar.getProgress())));
+          reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
+              new ReactSliderEvent(
+                  seekbar.getId(),
+                  ((ReactSlider)seekbar).toRealProgress(seekbar.getProgress()), false));
         }
       };
 

--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -94,7 +94,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
         @Override
         public void onStartTrackingTouch(SeekBar seekbar) {
           ReactContext reactContext = (ReactContext) seekbar.getContext();
-          ((ReactSlider)seekbar).isSliding = true;
+          ((ReactSlider)seekbar).isSliding(true);
           reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
               new ReactSlidingStartEvent(
                   seekbar.getId(),
@@ -104,7 +104,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
         @Override
         public void onStopTrackingTouch(SeekBar seekbar) {
           ReactContext reactContext = (ReactContext) seekbar.getContext();
-          ((ReactSlider)seekbar).isSliding = false;
+          ((ReactSlider)seekbar).isSliding(false);
           reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
               new ReactSlidingCompleteEvent(
                   seekbar.getId(),
@@ -149,7 +149,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
 
   @ReactProp(name = "value", defaultDouble = 0d)
   public void setValue(ReactSlider view, double value) {
-    if (view.isSliding == false) {
+    if (view.isSliding() == false) {
       view.setOnSeekBarChangeListener(null);
       view.setValue(value);
       view.setOnSeekBarChangeListener(ON_CHANGE_LISTENER);

--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -94,6 +94,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
         @Override
         public void onStartTrackingTouch(SeekBar seekbar) {
           ReactContext reactContext = (ReactContext) seekbar.getContext();
+          ((ReactSlider)seekbar).isSliding = true;
           reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
               new ReactSlidingStartEvent(
                   seekbar.getId(),
@@ -103,6 +104,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
         @Override
         public void onStopTrackingTouch(SeekBar seekbar) {
           ReactContext reactContext = (ReactContext) seekbar.getContext();
+          ((ReactSlider)seekbar).isSliding = false;
           reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
               new ReactSlidingCompleteEvent(
                   seekbar.getId(),
@@ -147,11 +149,13 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
 
   @ReactProp(name = "value", defaultDouble = 0d)
   public void setValue(ReactSlider view, double value) {
-    view.setOnSeekBarChangeListener(null);
-    view.setValue(value);
-    view.setOnSeekBarChangeListener(ON_CHANGE_LISTENER);
-    if (view.isAccessibilityFocused() && Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
-      view.setupAccessibility((int)value);
+    if (view.isSliding == false) {
+      view.setOnSeekBarChangeListener(null);
+      view.setValue(value);
+      view.setOnSeekBarChangeListener(ON_CHANGE_LISTENER);
+      if (view.isAccessibilityFocused() && Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
+        view.setupAccessibility((int)value);
+      }
     }
   }
 

--- a/src/ios/RNCSlider.h
+++ b/src/ios/RNCSlider.h
@@ -17,6 +17,7 @@
 
 @property (nonatomic, assign) float step;
 @property (nonatomic, assign) float lastValue;
+@property (nonatomic, assign) bool isSliding;
 
 @property (nonatomic, strong) UIImage *trackImage;
 @property (nonatomic, strong) UIImage *minimumTrackImage;

--- a/src/windows/SliderWindows/SliderView.cpp
+++ b/src/windows/SliderWindows/SliderView.cpp
@@ -22,7 +22,7 @@ namespace winrt {
 
 namespace winrt::SliderWindows::implementation {
 
-    SliderView::SliderView(winrt::IReactContext const& reactContext) : m_reactContext(reactContext), onSlidingStartSent(false) {
+    SliderView::SliderView(winrt::IReactContext const& reactContext) : m_reactContext(reactContext), isSliding(false) {
         RegisterEvents();
     }
 
@@ -55,10 +55,6 @@ namespace winrt::SliderWindows::implementation {
     void SliderView::UpdateProperties(winrt::IJSValueReader const& reader) {
         m_updating = true;
 
-        bool updatedValue = false;
-        bool updatedMaxValue = false;
-        bool updatedMinValue = false;
-
         auto const& propertyMap = JSValueObject::ReadFrom(reader);
 
         for (auto const& pair : propertyMap) {
@@ -69,9 +65,9 @@ namespace winrt::SliderWindows::implementation {
                 if (propertyValue.IsNull()) {
                     this->ClearValue(xaml::Controls::Primitives::RangeBase::ValueProperty());
                 }
-                else if (!onSlidingStartSent && onSlidingCompleteSent) {
-                    updatedValue = true;
+                else if (!isSliding) {
                     m_value = propertyValue.AsDouble();
+                    this->Value( m_value );
                 }
             }
             else if (propertyName == "maximumValue") {
@@ -79,8 +75,8 @@ namespace winrt::SliderWindows::implementation {
                     this->ClearValue(xaml::Controls::Primitives::RangeBase::MaximumProperty());
                 }
                 else {
-                    updatedMaxValue = true;
                     m_maxValue = propertyValue.AsDouble();
+                    this->Maximum( m_maxValue );
                 }
             }
             else if (propertyName == "minimumValue") {
@@ -88,8 +84,8 @@ namespace winrt::SliderWindows::implementation {
                     this->ClearValue(xaml::Controls::Primitives::RangeBase::MinimumProperty());
                 }
                 else {
-                    updatedMinValue = true;
                     m_minValue = propertyValue.AsDouble();
+                    this->Minimum( m_minValue );
                 }
             }
             else if (propertyName == "step") {
@@ -169,17 +165,6 @@ namespace winrt::SliderWindows::implementation {
             }
         }
 
-        // This is to mitigate platform bugs related to the order of setting min/max values in certain XAML controls.
-        if (updatedMaxValue) {
-            this->Maximum(m_maxValue);
-        }
-        if (updatedMinValue) {
-            this->Minimum(m_minValue);
-        }
-        if (updatedValue) {
-            this->Value(m_value);
-        }
-
         m_updating = false;
     }
 
@@ -208,6 +193,7 @@ namespace winrt::SliderWindows::implementation {
     void SliderView::OnManipulationStartingHandler( winrt::IInspectable const& sender,
         xaml::Input::ManipulationStartingRoutedEventArgs const& args )
     {
+        isSliding = true;
         if( !m_updating && !onSlidingStartSent )
         {
             auto self = sender.try_as<xaml::Controls::Slider>();
@@ -238,6 +224,7 @@ namespace winrt::SliderWindows::implementation {
                         eventDataWriter.WriteObjectEnd();
                     } );
                 onSlidingCompleteSent = true;
+                isSliding = false;
             }
             onValueChangeSent = false;
         }
@@ -246,7 +233,7 @@ namespace winrt::SliderWindows::implementation {
     void SliderView::OnManipulationCompletedHandler( winrt::IInspectable const& sender,
         xaml::Input::ManipulationCompletedRoutedEventArgs const& args )
     {
-        if( !m_updating && onSlidingCompleteSent == false )
+        if( !m_updating )
         {
             auto self = sender.try_as<xaml::Controls::Slider>();
 
@@ -265,6 +252,7 @@ namespace winrt::SliderWindows::implementation {
             onValueChangeSent = false;
             onSlidingStartSent = false;
         }
+        isSliding = false;
     }
 
     const double SliderView::CalculateStepFrequencyPercentageValue(const double& stepPropertyValue) const noexcept {

--- a/src/windows/SliderWindows/SliderView.cpp
+++ b/src/windows/SliderWindows/SliderView.cpp
@@ -22,7 +22,7 @@ namespace winrt {
 
 namespace winrt::SliderWindows::implementation {
 
-    SliderView::SliderView(winrt::IReactContext const& reactContext) : m_reactContext(reactContext) {
+    SliderView::SliderView(winrt::IReactContext const& reactContext) : m_reactContext(reactContext), onSlidingStartSent(false) {
         RegisterEvents();
     }
 
@@ -69,7 +69,7 @@ namespace winrt::SliderWindows::implementation {
                 if (propertyValue.IsNull()) {
                     this->ClearValue(xaml::Controls::Primitives::RangeBase::ValueProperty());
                 }
-                else {
+                else if (!onSlidingStartSent && onSlidingCompleteSent) {
                     updatedValue = true;
                     m_value = propertyValue.AsDouble();
                 }
@@ -200,13 +200,15 @@ namespace winrt::SliderWindows::implementation {
                     eventDataWriter.WriteObjectEnd();
                 } );
             onValueChangeSent = true;
+            onSlidingCompleteSent = false;
+            onSlidingStartSent = false;
         }
     }
 
     void SliderView::OnManipulationStartingHandler( winrt::IInspectable const& sender,
         xaml::Input::ManipulationStartingRoutedEventArgs const& args )
     {
-        if( !m_updating )
+        if( !m_updating && !onSlidingStartSent )
         {
             auto self = sender.try_as<xaml::Controls::Slider>();
 
@@ -238,8 +240,6 @@ namespace winrt::SliderWindows::implementation {
                 onSlidingCompleteSent = true;
             }
             onValueChangeSent = false;
-            onSlidingStartSent = true;
-            onSlidingCompleteSent = false;
         }
     }
 
@@ -263,6 +263,7 @@ namespace winrt::SliderWindows::implementation {
                 } );
             onSlidingCompleteSent = true;
             onValueChangeSent = false;
+            onSlidingStartSent = false;
         }
     }
 

--- a/src/windows/SliderWindows/SliderView.h
+++ b/src/windows/SliderWindows/SliderView.h
@@ -40,6 +40,8 @@ namespace winrt::SliderWindows::implementation {
         double m_maxValue, m_minValue;
         double m_value;
 
+        bool isSliding;
+
         bool onValueChangeSent, onSlidingStartSent, onSlidingCompleteSent;
     };
 }


### PR DESCRIPTION
**This pull request closes #292**

It introduces the improved control over the `value` property of the Slider and provides the user with the ability to control the thumb either by updating the `value` externally or by dragging/tapping the thumb.

(*This pull request also fixes #295 and closes #192*)

**NOTE:** This pull request affects all three platforms: iOS, Windows, Android

---

**How to use the new controlled `value` property?**

The `value` property should be considered **write-only**.
* It still does not need to be updated during dragging.
* Value written to that property will affect thumb's position immediately
* Updates to the `value` property **does not trigger** the `OnValueChange` event
What is programmatically written into `value` property should be tracked in the developer's implementation.
* Updates to the thumb's position (either by tap or drag) **will trigger** the `OnValueChange` event just like before

**What about the backward compatibility?**
It should not affect your current implementation.<br/>Unless you already had any update to the `value` prop implemented, you won't observe any change in the behavior of `<Slider/>`.
If you did have the `value` being updated somehow in your component, please adjust the implementation to separate the value of Slider and the value of your component.

In case of any problems or questions please report an issue.

---

**How does it work?**

To present the new controlled value let's use the example given in [this comment](https://github.com/callstack/react-native-slider/issues/295#issuecomment-893464169),
**but**
let's remove the `seeking` ref, we don't need it anymore :)

```javascript
const VideoComponent = () => {
  const [value, setValue] = useState(0);

  useEffect(() => {
    setInterval(() => {
      setValue((v) => v + 1);
    }, 50);
  }, []);

  const handleSeek = (val) => {
    setValue(val);
  };

  return (
    <View style={styles.container}>
      <Text style={styles.text}>{value}</Text>
      <Slider
        value={value}
        minimumValue={0}
        maximumValue={1000}
        step={1}
        minimumTrackTintColor="green"
        maximumTrackTintColor="red"
        onValueChange={(progress) => {
          console.log("value change", progress);
        }}
        onSlidingStart={(progress) => {
          console.log("sliding start at: %d", progress);
        }}
        onSlidingComplete={(progress) => {
          handleSeek(progress);
          console.log("sliding complete", progress);
        }}
      />
    </View>
  );
};
```
This will result in the following behavior:
![SliderReproDrag](https://user-images.githubusercontent.com/70535775/149841897-5bdedfe5-b7ae-4323-8fa2-0b869e4c50a9.gif)

---

**Implementation details**

The `value` property was previously used as an initial value of the `<Slider/>`. Changing this property would however update the position of the thumb, but the main issue was that such update was in conflict with the "manual" dragging of the thumb.

So the Slider **was a controlled component** under the hood, but this feature was unreliable and was not working.

This implementation fixes several issues with the `value` property itself, but the main feature added is that `<Slider/>` will now differentiate between `value` updated externally (programmatically) and `value` updated by user's action.
**Priority will be for user's action.** Each time user manipulates the `<Slider/>`, **no** external value will be accepted.
For iOS the implementation also changed the `value` to be the custom field with sliding condition.

---

For more questions or in case of any problem please report an issue.