### PR TITLE
Ignore all node_modules

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -5,19 +5,11 @@
 ; Ignore "BUCK" generated dirs
 <PROJECT_ROOT>/\.buckd/
 
-; Ignore polyfills
-node_modules/react-native/Libraries/polyfills/.*
-
-; These should not be required directly
-; require from fbjs/lib instead: require('fbjs/lib/warning')
-node_modules/warning/.*
+; Ignore node_modules
+<PROJECT_ROOT>/node_modules/.*
 
 ; Flow doesn't support platforms
 .*/Libraries/Utilities/LoadingView.js
-
-; These should not be required directly
-; require from fbjs/lib instead: require('fbjs/lib/warning')
-node_modules/warning/.*
 
 ; Flow doesn't support platforms
 .*/Libraries/Utilities/HMRLoadingView.js


### PR DESCRIPTION
This pull request ignores all libraries in *node_modules* directory when it comes to flow checks.

Reasoning behind it:
* Some modules have their files malformed in purpose which leads to flow check fails for them, see facebook/flow#2364
* This fixes errors in dependabot PR #348 
* This speeds up the flow check of the sources in this library, reducing the CI minutes.

All comments against this change are welcomed.