### PR TITLE
Fix: Conflicting states for accessibility and non-accessibility users

### DIFF
--- a/example/SliderExample.js
+++ b/example/SliderExample.js
@@ -227,13 +227,14 @@ export const examples = [
     title: 'Disabled slider',
     platform: 'android',
     render(): Element<any> {
-      return (
-        <SliderExample
-          disabled
-          accessibilityState={{disabled: false}}
-          value={0.6}
-        />
-      );
+      return <SliderExample disabled value={0.6} />;
+    },
+  },
+  {
+    title: 'Slider with accessibilityState disabled',
+    platform: 'android',
+    render(): Element<any> {
+      return <SliderExample disabled value={0.6} />;
     },
   },
 ];

--- a/example/SliderExample.js
+++ b/example/SliderExample.js
@@ -223,4 +223,17 @@ export const examples = [
       return <SliderExample value={0.6} vertical />;
     },
   },
+  {
+    title: 'Disabled slider',
+    platform: 'android',
+    render(): Element<any> {
+      return (
+        <SliderExample
+          disabled
+          accessibilityState={{disabled: false}}
+          value={0.6}
+        />
+      );
+    },
+  },
 ];

--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -12,7 +12,6 @@ import android.graphics.BitmapFactory;
 import android.graphics.drawable.BitmapDrawable;
 import android.os.Build;
 import android.util.AttributeSet;
-import android.view.MotionEvent;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 import androidx.appcompat.widget.AppCompatSeekBar;
@@ -151,17 +150,6 @@ public class ReactSlider extends AppCompatSeekBar {
       Timer timer = new Timer();
       timer.schedule(task, 1000);
     }
-  }
-
-  @Override
-  public boolean onTouchEvent(MotionEvent arg0) {
-    super.onTouchEvent(arg0);
-
-    if (arg0.getActionMasked() == MotionEvent.ACTION_DOWN && this.isEnabled() == false) {
-      announceForAccessibility("slider disabled");
-    }
-    // Returns: True if the view handled the hover event
-    return true;
   }
 
   public void setupAccessibility(int index) {

--- a/src/js/Slider.js
+++ b/src/js/Slider.js
@@ -21,7 +21,6 @@ import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
 import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
-import invariant from 'invariant';
 
 type Event = SyntheticEvent<
   $ReadOnly<{|
@@ -264,13 +263,6 @@ const SliderComponent = (
       }
     : null;
 
-  invariant(
-    typeof props.disabled === 'boolean' ||
-      typeof props.disabled === 'undefined',
-    '`disabled` prop must be set as a boolean, but got `' +
-      JSON.stringify(props.disabled ?? 'undefined') +
-      '`',
-  );
   const _disabled =
     typeof props.disabled === 'boolean'
       ? props.disabled

--- a/src/js/Slider.js
+++ b/src/js/Slider.js
@@ -265,7 +265,8 @@ const SliderComponent = (
     : null;
 
   invariant(
-    typeof props.disabled === 'boolean' || !(props.disabled != null),
+    typeof props.disabled === 'boolean' ||
+      typeof props.disabled === 'undefined',
     '`disabled` prop must be set as a boolean, but got `' +
       JSON.stringify(props.disabled ?? 'undefined') +
       '`',

--- a/src/js/Slider.js
+++ b/src/js/Slider.js
@@ -268,6 +268,18 @@ const SliderComponent = (
       ? props.disabled
       : props.accessibilityState?.disabled === true;
 
+  const overridesAccessibilityState =
+    typeof props.disabled === 'boolean' &&
+    props.accessibilityState?.disabled !== props.disabled;
+  if (overridesAccessibilityState) {
+    console.warn(
+      `Detected a conflicting state for accessibility and non-accessibility users. The prop disabled with value of ${
+        props.disabled
+      } for slider overrides the accessibilityState.disabled with value of ${
+        props.accessibilityState?.disabled
+      }`,
+    );
+  }
   const _accessibilityState =
     typeof props.disabled === 'boolean'
       ? {...props.accessibilityState, disabled: props.disabled}

--- a/src/js/Slider.js
+++ b/src/js/Slider.js
@@ -273,11 +273,7 @@ const SliderComponent = (
     props.accessibilityState?.disabled !== props.disabled;
   if (overridesAccessibilityState) {
     console.warn(
-      `Detected a conflicting state for accessibility and non-accessibility users. The prop disabled with value of ${
-        props.disabled
-      } for slider overrides the accessibilityState.disabled with value of ${
-        props.accessibilityState?.disabled
-      }`,
+      `We detected a conflicting state for accessibility and non-accessibility users. The disabled prop of the Slider component has a different value from accessibilityState.disabled. The prop disabled overrides the accessibilityState.`,
     );
   }
   const _accessibilityState =

--- a/src/js/Slider.js
+++ b/src/js/Slider.js
@@ -263,6 +263,16 @@ const SliderComponent = (
       }
     : null;
 
+  const _disabled =
+    typeof props.disabled === 'boolean'
+      ? props.disabled
+      : props.accessibilityState?.disabled === true;
+
+  const _accessibilityState =
+    typeof props.disabled === 'boolean'
+      ? {...props.accessibilityState, disabled: props.disabled}
+      : props.accessibilityState;
+
   const onChangeEvent = onValueChangeEvent;
   const onSlidingStartEvent = onSlidingStart
     ? (event: Event) => {
@@ -289,9 +299,11 @@ const SliderComponent = (
       onRNCSliderSlidingStart={onSlidingStartEvent}
       onRNCSliderSlidingComplete={onSlidingCompleteEvent}
       onRNCSliderValueChange={onValueChangeEvent}
-      enabled={!props.disabled}
+      enabled={!_disabled}
+      disabled={_disabled}
       onStartShouldSetResponder={() => true}
       onResponderTerminationRequest={() => false}
+      accessibilityState={_accessibilityState}
     />
   );
 };
@@ -303,7 +315,6 @@ const SliderWithRef = React.forwardRef(SliderComponent);
  * and run Flow. */
 
 SliderWithRef.defaultProps = {
-  disabled: false,
   value: 0,
   minimumValue: 0,
   maximumValue: 1,

--- a/src/js/Slider.js
+++ b/src/js/Slider.js
@@ -268,14 +268,6 @@ const SliderComponent = (
       ? props.disabled
       : props.accessibilityState?.disabled === true;
 
-  const overridesAccessibilityState =
-    typeof props.disabled === 'boolean' &&
-    props.accessibilityState?.disabled !== props.disabled;
-  if (overridesAccessibilityState) {
-    console.warn(
-      `We detected a conflicting state for accessibility and non-accessibility users. The disabled prop of the Slider component has a different value from accessibilityState.disabled. The prop disabled overrides the accessibilityState.`,
-    );
-  }
   const _accessibilityState =
     typeof props.disabled === 'boolean'
       ? {...props.accessibilityState, disabled: props.disabled}

--- a/src/js/Slider.js
+++ b/src/js/Slider.js
@@ -21,6 +21,7 @@ import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
 import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import invariant from 'invariant';
 
 type Event = SyntheticEvent<
   $ReadOnly<{|
@@ -263,6 +264,12 @@ const SliderComponent = (
       }
     : null;
 
+  invariant(
+    typeof props.disabled === 'boolean' || !(props.disabled != null),
+    '`disabled` prop must be set as a boolean, but got `' +
+      JSON.stringify(props.disabled ?? 'undefined') +
+      '`',
+  );
   const _disabled =
     typeof props.disabled === 'boolean'
       ? props.disabled

--- a/src/js/__tests__/Slider.test.js
+++ b/src/js/__tests__/Slider.test.js
@@ -17,7 +17,7 @@ describe('<Slider />', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('accessibilityState disabled renders a disabled slider', () => {
+  it('accessibilityState disabled sets disabled={true}', () => {
     const tree = renderer
       .create(<Slider accessibilityState={{disabled: true}} />)
       .toJSON();
@@ -25,7 +25,7 @@ describe('<Slider />', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('the disabled prop will change the accessibilityState.disabled value', () => {
+  it('disabled prop overrides accessibilityState.disabled', () => {
     const tree = renderer
       .create(<Slider disabled accessibilityState={{disabled: false}} />)
       .toJSON();

--- a/src/js/__tests__/Slider.test.js
+++ b/src/js/__tests__/Slider.test.js
@@ -17,6 +17,22 @@ describe('<Slider />', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('accessibilityState disabled renders a disabled slider', () => {
+    const tree = renderer
+      .create(<Slider accessibilityState={{disabled: true}} />)
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('the disabled prop will change the accessibilityState.disabled value', () => {
+    const tree = renderer
+      .create(<Slider disabled accessibilityState={{disabled: false}} />)
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
   it('renders a slider with custom props', () => {
     const tree = renderer
       .create(

--- a/src/js/__tests__/Slider.test.js
+++ b/src/js/__tests__/Slider.test.js
@@ -33,6 +33,14 @@ describe('<Slider />', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('disabled prop overrides accessibilityState.enabled', () => {
+    const tree = renderer
+      .create(<Slider disabled={false} accessibilityState={{disabled: true}} />)
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
   it('renders a slider with custom props', () => {
     const tree = renderer
       .create(

--- a/src/js/__tests__/__snapshots__/Slider.test.js.snap
+++ b/src/js/__tests__/__snapshots__/Slider.test.js.snap
@@ -1,6 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Slider /> accessibilityState disabled renders a disabled slider 1`] = `
+exports[`<Slider /> accessibilityState disabled sets disabled={true} 1`] = `
+<RNCSlider
+  accessibilityState={
+    Object {
+      "disabled": true,
+    }
+  }
+  disabled={true}
+  enabled={false}
+  inverted={false}
+  maximumValue={1}
+  minimumValue={0}
+  onChange={null}
+  onRNCSliderSlidingComplete={null}
+  onRNCSliderSlidingStart={null}
+  onRNCSliderValueChange={null}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  step={0}
+  style={
+    Object {
+      "height": 40,
+    }
+  }
+  tapToSeek={false}
+  thumbImage={null}
+  value={0}
+/>
+`;
+
+exports[`<Slider /> disabled prop overrides accessibilityState.disabled 1`] = `
 <RNCSlider
   accessibilityState={
     Object {
@@ -92,36 +122,6 @@ exports[`<Slider /> renders enabled slider 1`] = `
 <RNCSlider
   disabled={false}
   enabled={true}
-  inverted={false}
-  maximumValue={1}
-  minimumValue={0}
-  onChange={null}
-  onRNCSliderSlidingComplete={null}
-  onRNCSliderSlidingStart={null}
-  onRNCSliderValueChange={null}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  step={0}
-  style={
-    Object {
-      "height": 40,
-    }
-  }
-  tapToSeek={false}
-  thumbImage={null}
-  value={0}
-/>
-`;
-
-exports[`<Slider /> the disabled prop will change the accessibilityState.disabled value 1`] = `
-<RNCSlider
-  accessibilityState={
-    Object {
-      "disabled": true,
-    }
-  }
-  disabled={true}
-  enabled={false}
   inverted={false}
   maximumValue={1}
   minimumValue={0}

--- a/src/js/__tests__/__snapshots__/Slider.test.js.snap
+++ b/src/js/__tests__/__snapshots__/Slider.test.js.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Slider /> accessibilityState disabled renders a disabled slider 1`] = `
+<RNCSlider
+  accessibilityState={
+    Object {
+      "disabled": true,
+    }
+  }
+  disabled={true}
+  enabled={false}
+  inverted={false}
+  maximumValue={1}
+  minimumValue={0}
+  onChange={null}
+  onRNCSliderSlidingComplete={null}
+  onRNCSliderSlidingStart={null}
+  onRNCSliderValueChange={null}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  step={0}
+  style={
+    Object {
+      "height": 40,
+    }
+  }
+  tapToSeek={false}
+  thumbImage={null}
+  value={0}
+/>
+`;
+
 exports[`<Slider /> renders a slider with custom props 1`] = `
 <RNCSlider
   disabled={false}
@@ -30,6 +60,11 @@ exports[`<Slider /> renders a slider with custom props 1`] = `
 
 exports[`<Slider /> renders disabled slider 1`] = `
 <RNCSlider
+  accessibilityState={
+    Object {
+      "disabled": true,
+    }
+  }
   disabled={true}
   enabled={false}
   inverted={false}
@@ -57,6 +92,36 @@ exports[`<Slider /> renders enabled slider 1`] = `
 <RNCSlider
   disabled={false}
   enabled={true}
+  inverted={false}
+  maximumValue={1}
+  minimumValue={0}
+  onChange={null}
+  onRNCSliderSlidingComplete={null}
+  onRNCSliderSlidingStart={null}
+  onRNCSliderValueChange={null}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  step={0}
+  style={
+    Object {
+      "height": 40,
+    }
+  }
+  tapToSeek={false}
+  thumbImage={null}
+  value={0}
+/>
+`;
+
+exports[`<Slider /> the disabled prop will change the accessibilityState.disabled value 1`] = `
+<RNCSlider
+  accessibilityState={
+    Object {
+      "disabled": true,
+    }
+  }
+  disabled={true}
+  enabled={false}
   inverted={false}
   maximumValue={1}
   minimumValue={0}

--- a/src/js/__tests__/__snapshots__/Slider.test.js.snap
+++ b/src/js/__tests__/__snapshots__/Slider.test.js.snap
@@ -142,3 +142,33 @@ exports[`<Slider /> renders enabled slider 1`] = `
   value={0}
 />
 `;
+
+exports[`<Slider /> disabled prop overrides accessibilityState.enabled 1`] = `
+<RNCSlider
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  disabled={false}
+  enabled={true}
+  inverted={false}
+  maximumValue={1}
+  minimumValue={0}
+  onChange={null}
+  onRNCSliderSlidingComplete={null}
+  onRNCSliderSlidingStart={null}
+  onRNCSliderValueChange={null}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  step={0}
+  style={
+    Object {
+      "height": 40,
+    }
+  }
+  tapToSeek={false}
+  thumbImage={null}
+  value={0}
+/>
+`;


### PR DESCRIPTION
Summary:
---------

This issue fixes https://github.com/facebook/react-native/issues/30939 fixes https://github.com/facebook/react-native/issues/30840 ([Test Case 7.1][7.1], [Test Case 7.3][7.3], [Test Case 7.5][7.5]) .
The issue is caused by the missing prop `accessibilityState` in the Slider component.

The solution consists of passing the accessibilityState to the `RCTSliderNativeComponent` component as previously implemented in other components (for example, [Button][8]). 

Relevant discussions https://github.com/facebook/react-native/issues/30840#issuecomment-780981316 and https://github.com/facebook/react-native/pull/31001/files#r578827409.

[8]: https://github.com/facebook/react-native/pull/31224/files#diff-ab227579e3dfe69ff9b4952a09cf8ae78783e6fd9c2820f3c038e02c7406a6cdR171

The solution proposed in this pull request consists of:
1. removing the disabled default prop (related discussions https://github.com/fabriziobertoglio1987/react-native-slider/commit/fc9f0c4b6a30cb6b839fd0229464a167caff9303 and https://github.com/fabriziobertoglio1987/react-native/commit/afb7fc2aabe3db6e79e4afbea9d99fd926c80362).
2. If the value of prop `accessibilityState.disabled` is different from the prop `disabled`, the prop `disabled` over-rides the `accessibilityState.disabled` value.

For example:
```jsx
<Slider disabled={true} accessibilityState={{disabled: false}} />
````
becomes:
````jsx
<Slider disabled={true} accessibilityState={{disabled: true}} />
````
3. Remove the existing Android java logic

An alternative Solution published in [this branch](URL) would be:
- not removing the default prop for disabled (false).
- `disabled` default prop `false` over-rides `accessibilityState.disabled`

This alternative solution would not respect the [requirement](https://github.com/facebook/react-native/pull/31001/files#r578827409) of not having `conflicting states for accessibility and non-accessibility users` and the approach adopted in react-native Components (for ex. [Button](https://github.com/facebook/react-native/pull/31001)).

For example:
```jsx
<Slider accessibilityState={{disabled: true}} />
``` 
would become (as the deafult is `disabled={false}`)
```jsx
<Slider accessibilityState={{disabled: false}} />
```

**<details><summary>ADDITIONAL NOTES</summary>**
<p>

- `<Slider disabled={"true"} />` triggers a [wrong type warning](https://github.com/fabriziobertoglio1987/react-native-notes/issues/2#issuecomment-1023790902) with typescript.
-  `<Slider disabled={"true"} />` does **not** trigger a [wrong type warning](https://github.com/fabriziobertoglio1987/react-native-notes/issues/2#issuecomment-1023764493) with flow.js.
</p>
</details>


Test Plan:
----------

**Android**:

[1]. Slider has `disabled` and `accessibilityState={{disabled: false}}`
[2]. Slider has `disabled`
[3]. Slider has `accessibilityState={{disabled: true}}`
[4]. Slider has `accessibilityState={{disabled:false}}`
[5]. Slider has `disabled={false}`  and `accessibilityState={{disabled:true}}`
7. Test Cases on the main branch
[7.1]. Slider has `disabled` and `accessibilityState={{disabled: false}}`
[7.3] Slider has `accessibilityState={{disabled: true}}`
[7.5] Slider has `disabled={false}`  and `accessibilityState={{disabled:true}}`
[7.6] Wrong prop type `disabled="not a boolean value"`  with typescript
[7.7] Wrong prop type `disabled="not a boolean value"`  with flow on the master branch

[1]: https://github.com/fabriziobertoglio1987/react-native-notes/issues/2#issue-1113396741
[2]: https://github.com/fabriziobertoglio1987/react-native-notes/issues/2#issuecomment-1020801653
[3]: https://github.com/fabriziobertoglio1987/react-native-notes/issues/2#issuecomment-1020803041
[4]: https://github.com/fabriziobertoglio1987/react-native-notes/issues/2#issuecomment-1020804872
[5]: https://github.com/fabriziobertoglio1987/react-native-notes/issues/2#issuecomment-1020860457
[6]: https://github.com/fabriziobertoglio1987/react-native-notes/issues/2#issuecomment-1022687166
[7.1]: https://github.com/fabriziobertoglio1987/react-native-notes/issues/2#issuecomment-1023936727
[7.3]: https://github.com/fabriziobertoglio1987/react-native-notes/issues/2#issuecomment-1023934920
[7.5]: https://github.com/fabriziobertoglio1987/react-native-notes/issues/2#issuecomment-1023793176
[7.6]: https://github.com/fabriziobertoglio1987/react-native-notes/issues/2#issuecomment-1023790902
[7.7]: https://github.com/fabriziobertoglio1987/react-native-notes/issues/2#issuecomment-1023764493