### PR TITLE
Fix: onAccessibilityAction causes crash

### DIFF
--- a/src/js/Slider.js
+++ b/src/js/Slider.js
@@ -11,7 +11,7 @@
 'use strict';
 
 import React from 'react';
-import {Image, Platform, StyleSheet} from 'react-native';
+import {Image, Platform, StyleSheet, AccessibilityActionEvent} from 'react-native';
 import RCTSliderNativeComponent from './RNCSliderNativeComponent';
 
 import type {Ref} from 'react';
@@ -286,7 +286,7 @@ const SliderComponent = (
       }
     : null;
   const onAccessibilityActionEvent = onAccessibilityAction
-    ? (event: Event) => {
+    ? (event: AccessibilityActionEvent) => {
         onAccessibilityAction(event.nativeEvent.value);
       }
     : null;

--- a/src/js/Slider.js
+++ b/src/js/Slider.js
@@ -11,7 +11,12 @@
 'use strict';
 
 import React from 'react';
-import {Image, Platform, StyleSheet, AccessibilityActionEvent} from 'react-native';
+import {
+  Image,
+  Platform,
+  StyleSheet,
+  AccessibilityActionEvent,
+} from 'react-native';
 import RCTSliderNativeComponent from './RNCSliderNativeComponent';
 
 import type {Ref} from 'react';

--- a/src/js/Slider.js
+++ b/src/js/Slider.js
@@ -247,6 +247,7 @@ const SliderComponent = (
     onValueChange,
     onSlidingStart,
     onSlidingComplete,
+    onAccessibilityAction,
     ...localProps
   } = props;
 
@@ -284,6 +285,11 @@ const SliderComponent = (
         onSlidingComplete(event.nativeEvent.value);
       }
     : null;
+  const onAccessibilityActionEvent = onAccessibilityAction
+    ? (event: Event) => {
+        onAccessibilityAction(event.nativeEvent.value);
+      }
+    : null;
 
   return (
     <RCTSliderNativeComponent
@@ -304,6 +310,7 @@ const SliderComponent = (
       onStartShouldSetResponder={() => true}
       onResponderTerminationRequest={() => false}
       accessibilityState={_accessibilityState}
+      onRNCSliderAccessibilityAction={onAccessibilityActionEvent}
     />
   );
 };

--- a/src/js/__tests__/__snapshots__/Slider.test.js.snap
+++ b/src/js/__tests__/__snapshots__/Slider.test.js.snap
@@ -13,6 +13,7 @@ exports[`<Slider /> accessibilityState disabled sets disabled={true} 1`] = `
   maximumValue={1}
   minimumValue={0}
   onChange={null}
+  onRNCSliderAccessibilityAction={null}
   onRNCSliderSlidingComplete={null}
   onRNCSliderSlidingStart={null}
   onRNCSliderValueChange={null}
@@ -43,6 +44,38 @@ exports[`<Slider /> disabled prop overrides accessibilityState.disabled 1`] = `
   maximumValue={1}
   minimumValue={0}
   onChange={null}
+  onRNCSliderAccessibilityAction={null}
+  onRNCSliderSlidingComplete={null}
+  onRNCSliderSlidingStart={null}
+  onRNCSliderValueChange={null}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  step={0}
+  style={
+    Object {
+      "height": 40,
+    }
+  }
+  tapToSeek={false}
+  thumbImage={null}
+  value={0}
+/>
+`;
+
+exports[`<Slider /> disabled prop overrides accessibilityState.enabled 1`] = `
+<RNCSlider
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  disabled={false}
+  enabled={true}
+  inverted={false}
+  maximumValue={1}
+  minimumValue={0}
+  onChange={null}
+  onRNCSliderAccessibilityAction={null}
   onRNCSliderSlidingComplete={null}
   onRNCSliderSlidingStart={null}
   onRNCSliderValueChange={null}
@@ -70,6 +103,7 @@ exports[`<Slider /> renders a slider with custom props 1`] = `
   minimumTrackTintColor="blue"
   minimumValue={-1}
   onChange={[Function]}
+  onRNCSliderAccessibilityAction={null}
   onRNCSliderSlidingComplete={[Function]}
   onRNCSliderSlidingStart={null}
   onRNCSliderValueChange={[Function]}
@@ -101,6 +135,7 @@ exports[`<Slider /> renders disabled slider 1`] = `
   maximumValue={1}
   minimumValue={0}
   onChange={null}
+  onRNCSliderAccessibilityAction={null}
   onRNCSliderSlidingComplete={null}
   onRNCSliderSlidingStart={null}
   onRNCSliderValueChange={null}
@@ -126,36 +161,7 @@ exports[`<Slider /> renders enabled slider 1`] = `
   maximumValue={1}
   minimumValue={0}
   onChange={null}
-  onRNCSliderSlidingComplete={null}
-  onRNCSliderSlidingStart={null}
-  onRNCSliderValueChange={null}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
-  step={0}
-  style={
-    Object {
-      "height": 40,
-    }
-  }
-  tapToSeek={false}
-  thumbImage={null}
-  value={0}
-/>
-`;
-
-exports[`<Slider /> disabled prop overrides accessibilityState.enabled 1`] = `
-<RNCSlider
-  accessibilityState={
-    Object {
-      "disabled": false,
-    }
-  }
-  disabled={false}
-  enabled={true}
-  inverted={false}
-  maximumValue={1}
-  minimumValue={0}
-  onChange={null}
+  onRNCSliderAccessibilityAction={null}
   onRNCSliderSlidingComplete={null}
   onRNCSliderSlidingStart={null}
   onRNCSliderValueChange={null}


### PR DESCRIPTION
This pull request fixes #250
It adds the explicit implementation of utilizing the `onAccessibilityAction` property passed to the Slider exposed to JS side.

The implementation **does not** overrides the implementation of the event itself, but it takes that property directly from props passed to Slider as part of `ViewProps`.
The extracted property is explicity passed to Slider component implementation.

Tested on simulator using the Accessibility Inspector from Xcode tools.