### PR TITLE
Fix: Type error when using Slider with props as ref

### DIFF
--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -150,7 +150,7 @@ export interface SliderProps extends SliderPropsIOS, SliderPropsAndroid, SliderP
   /**
    * Reference object.
    */
-  ref?: React.MutableRefObject<SliderRef>;
+  ref?: SliderReferenceType;
 }
 
 /**

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -1,6 +1,11 @@
 import * as React from "react";
 import * as ReactNative from "react-native";
 
+type SliderReferenceType = (
+  React.MutableRefObject<SliderRef> &
+  React.LegacyRef<Slider>
+) | undefined;
+
 export interface SliderPropsAndroid extends ReactNative.ViewProps {
   /**
    * Color of the foreground switch grip.


### PR DESCRIPTION
This pull request fixes #321 
It introduces new type that is used as a type of optional `ref` value.

Root cause of the type error was that when Slider is used for non-web, the props given as rest (see the repro example) are treated as ref object, which does not meet the type specified for web implementation.
To keep the web implementation safe within this fix, new type keeps it along with the type deduced for props object ref.
