### PR TITLE
Fix: SeekBar on Android is rendering incorrectly in RTL mode

### DIFF
--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import javax.annotation.Nullable;
-
+import com.facebook.react.modules.i18nmanager.I18nUtil;
 /**
  * Slider that behaves more like the iOS one, for consistency.
  *
@@ -68,6 +68,8 @@ public class ReactSlider extends AppCompatSeekBar {
 
   public ReactSlider(Context context, @Nullable AttributeSet attrs, int style) {
     super(context, attrs, style);
+    I18nUtil sharedI18nUtilInstance = I18nUtil.getInstance();
+    super.setLayoutDirection(sharedI18nUtilInstance.isRTL(context) ? LAYOUT_DIRECTION_RTL : LAYOUT_DIRECTION_LTR);
     disableStateListAnimatorIfNeeded();
   }
 


### PR DESCRIPTION
This pull request #370   fixes SeekBar rendering in RTL mode and also adds ability to change layoutDirection depends on isRTL RN property.

Summary:
---------
1. Slider renders incorrectly on Android in rtl mode.
2. Currently slider changes it's layout direction based on device language. I want that it was relying on isRTL value of RN instead. It's important in case if we don't have translations for some rtl language and we have to use English as a default.