### PR TITLE
Fix: Default/initial value ignored on Android

### DIFF
--- a/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/src/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -152,9 +152,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
   @ReactProp(name = "value", defaultDouble = 0d)
   public void setValue(ReactSlider view, double value) {
     if (view.isSliding() == false) {
-      view.setOnSeekBarChangeListener(null);
       view.setValue(value);
-      view.setOnSeekBarChangeListener(ON_CHANGE_LISTENER);
       if (view.isAccessibilityFocused() && Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
         view.setupAccessibility((int)value);
       }


### PR DESCRIPTION
This pull request fixes #377 

The fix is to avoid resetting the seekbar change listener when setting a value.
It turns out that when value is set for the first time (initial `value`) the seekbar is set, but it's resetting causes it to be removed and set to default Android's value of 0.
Removing the temporary blocking of setting the value fixes the issue.

---

This pull request has been also checked against the "controlled value" feature and defect of onChange not called.
Both these issues were not observed during testing the fix.
