### PR TITLE
Fix: ignored step value during dragging

### DIFF
--- a/src/ios/RNCSlider.h
+++ b/src/ios/RNCSlider.h
@@ -27,4 +27,6 @@
 @property (nonatomic, strong) NSString *accessibilityUnits;
 @property (nonatomic, strong) NSArray *accessibilityIncrements;
 
+- (float) discreteValue:(float)value;
+
 @end

--- a/src/ios/RNCSlider.m
+++ b/src/ios/RNCSlider.m
@@ -21,6 +21,7 @@
 
 - (void)setValue:(float)value
 {
+    value = [self discreteValue:value];
   _unclippedValue = value;
   super.value = value;
   [self setupAccessibility:value];
@@ -28,6 +29,7 @@
 
 - (void)setValue:(float)value animated:(BOOL)animated
 {
+    value = [self discreteValue:value];
   _unclippedValue = value;
   [super setValue:value animated:animated];
   [self setupAccessibility:value];
@@ -128,6 +130,31 @@
   } else {
     self.transform = CGAffineTransformMakeScale(1, 1);
   }
+}
+
+- (float)discreteValue:(float)value
+{
+    if (self.step > 0 && value >= self.maximumValue) {
+        return self.maximumValue;
+    }
+
+    if (self.step > 0 && self.step <= (self.maximumValue - self.minimumValue)) {
+        double (^_round)(double) = ^(double x) {
+            if (!UIAccessibilityIsVoiceOverRunning()) {
+                return round(x);
+            } else if (self.lastValue > value) {
+                return floor(x);
+            } else {
+                return ceil(x);
+            }
+        };
+
+        return MAX(self.minimumValue,
+            MIN(self.maximumValue, self.minimumValue + _round((value - self.minimumValue) / self.step) * self.step)
+        );
+    }
+
+    return value;
 }
 
 @end

--- a/src/ios/RNCSliderManager.m
+++ b/src/ios/RNCSliderManager.m
@@ -61,7 +61,7 @@ RCT_EXPORT_MODULE()
   slider.lastValue = slider.value;
   float value = slider.minimumValue + (rangeWidth * sliderPercent);
 
-  [slider setValue:discreteValue(slider, value) animated: YES];
+  [slider setValue:[slider discreteValue:value] animated: YES];
 
   if (slider.onRNCSliderSlidingStart) {
     slider.onRNCSliderSlidingStart(@{
@@ -83,43 +83,9 @@ RCT_EXPORT_MODULE()
   }
 }
 
-static float discreteValue(RNCSlider *sender, float value) {
-  // Check if thumb should reach the maximum value and put it on the end of track if yes.
-  // To avoid affecting the thumb when on maximum, the `step >= (value - maximum)` is not checked.
-  if (sender.step > 0 && value >= sender.maximumValue) {
-    return sender.maximumValue;
-  }
-
-  // If step is set and less than or equal to difference between max and min values,
-  // pick the closest discrete multiple of step to return.
-  if (sender.step > 0 && sender.step <= (sender.maximumValue - sender.minimumValue)) {
-    
-    // Round up when increase, round down when decrease.
-    double (^_round)(double) = ^(double x) {
-      if (!UIAccessibilityIsVoiceOverRunning()) {
-        return round(x);
-      } else if (sender.lastValue > value) {
-        return floor(x);
-      } else {
-        return ceil(x);
-      }
-    };
-
-    return
-      MAX(sender.minimumValue,
-        MIN(sender.maximumValue,
-            sender.minimumValue + _round((value - sender.minimumValue) / sender.step) * sender.step
-        )
-      );
-  }
-
-  // Otherwise, leave value unchanged.
-  return value;
-}
-
 static void RNCSendSliderEvent(RNCSlider *sender, BOOL continuous, BOOL isSlidingStart)
 {
-  float value = discreteValue(sender, sender.value);
+  float value = [sender discreteValue:sender.value];
 
   if(!sender.isSliding) {
     [sender setValue:value animated:NO];


### PR DESCRIPTION
This pull request fixes #390 
It allows to successfully use the `step` property which is considered during dragging and during programmatically control of the Slider.

The root cause of this issue was that the controlled `value` property modified the dragging logic changing the way the value is passed to `RNCSlider` instance according to sliding start and progress.
Due to that the `value` was given the unclipped value (uncalculated) during dragging which was assigned to the thumb only, but at the finish of the dragging the `value` of the whole component received the calculated one.
This resulted in observed smooth thumb transition, while `value` having the values respecting the `step` property.

The implementation of the fix moves the calculation of the discrete value which calculates the value according to the given step (if no step is given, the transition remains smooth).
The internal `discreteValue` calculation is utilized in both Slider Manager and Slider instance itself.

The results of the fix are presented below:

https://user-images.githubusercontent.com/70535775/176319528-125123bf-ba1e-4b26-91a0-90f02e52b1df.mov


