### PR TITLE
Fix: Pods-related error after using Pods from cache

### DIFF
--- a/.github/workflows/ReactNativeSlider-CI.yml
+++ b/.github/workflows/ReactNativeSlider-CI.yml
@@ -105,23 +105,36 @@ jobs:
         id: cache-npm
         uses: actions/cache@v3
         env:
-          cache-name: cached-ios-deps
+          cache-name: cached-ios-npm-deps
         with:
-          path: |
-            example/node_modules
-            example/ios/Pods
-          key: ${{ hashFiles('./example/package-lock.json') }}-${{ hashFiles('./package/package-lock.json') }}-${{ hashFiles('./example/ios/Podfile.lock') }}
+          path: example/node_modules
+          key: ${{ hashFiles('./example/package-lock.json') }}-${{ hashFiles('./package/package-lock.json') }}
 
       - name: Install required dependencies on cache miss (npm)
         if: steps.cache-npm.outputs.cache-hit != 'true'
         run: |
           npm install
 
-      - name: Use the current package sources in build
-        run: cd example && npm run refresh-package
+      - name: Cache Pods
+        id: cache-pods
+        uses: actions/cache@v3
+        env:
+          cache-name: cached-ios-pods-deps
+        with:
+          path: example/ios/Pods
+          key: ${{ hashFiles('./example/ios/Podfile.lock') }}
+
+      - name: Install required dependencies on cache miss (Pods)
+        if: steps.cache-pods.outputs.cache-hit != 'true'
+        run: |
+          cd example/ios && pod install
 
       - name: Reinstall Pods
+        if: steps.cache-pods.outputs.cache-hit == 'true'
         run: cd example/ios && pod install
+
+      - name: Use the current package sources in build
+        run: cd example && npm run refresh-package
 
       - name: Build iOS
         run: |
@@ -144,19 +157,32 @@ jobs:
         id: cache-npm
         uses: actions/cache@v3
         env:
-          cache-name: cached-ios-deps
+          cache-name: cached-ios-npm-deps
         with:
-          path: |
-            example/node_modules
-            example/ios/Pods
-          key: new-arch-${{ hashFiles('./example/package-lock.json') }}-${{ hashFiles('./package/package-lock.json') }}-${{ hashFiles('./example/ios/Podfile.lock') }}
+          path: example/node_modules
+          key: new-arch-${{ hashFiles('./example/package-lock.json') }}-${{ hashFiles('./package/package-lock.json') }}
 
       - name: Install required dependencies on cache miss (npm)
         if: steps.cache-npm.outputs.cache-hit != 'true'
         run: |
           npm install
 
+      - name: Cache Pods
+        id: cache-pods
+        uses: actions/cache@v3
+        env:
+          cache-name: cached-ios-pods-deps
+        with:
+          path: example/ios/Pods
+          key: new-arch-${{ hashFiles('./example/ios/Podfile.lock') }}
+
+      - name: Install required dependencies on cache miss (Pods)
+        if: steps.cache-pods.outputs.cache-hit != 'true'
+        run: |
+          cd example/ios && RCT_NEW_ARCH_ENABLED=1 pod install
+
       - name: Reinstall Pods
+        if: steps.cache-pods.outputs.cache-hit == 'true'
         run: cd example/ios && RCT_NEW_ARCH_ENABLED=1 pod install
 
       - name: Use the current package sources in build

--- a/.github/workflows/ReactNativeSlider-CI.yml
+++ b/.github/workflows/ReactNativeSlider-CI.yml
@@ -147,7 +147,7 @@ jobs:
           path: |
             example/node_modules
             example/ios/Pods
-          key: ${{ hashFiles('./example/package-lock.json') }}-${{ hashFiles('./package/package-lock.json') }}-${{ hashFiles('./example/ios/Podfile.lock') }}
+          key: new-arch-${{ hashFiles('./example/package-lock.json') }}-${{ hashFiles('./package/package-lock.json') }}-${{ hashFiles('./example/ios/Podfile.lock') }}
 
       - name: Install required dependencies on cache miss (npm)
         if: steps.cache-npm.outputs.cache-hit != 'true'

--- a/.github/workflows/ReactNativeSlider-CI.yml
+++ b/.github/workflows/ReactNativeSlider-CI.yml
@@ -116,10 +116,12 @@ jobs:
         if: steps.cache-npm.outputs.cache-hit != 'true'
         run: |
           npm install
-          cd example/ios && pod install
 
       - name: Use the current package sources in build
         run: cd example && npm run refresh-package
+
+      - name: Reinstall Pods
+        run: cd example/ios && pod install
 
       - name: Build iOS
         run: |
@@ -153,7 +155,9 @@ jobs:
         if: steps.cache-npm.outputs.cache-hit != 'true'
         run: |
           npm install
-          cd example/ios && RCT_NEW_ARCH_ENABLED=1 pod install
+
+      - name: Reinstall Pods
+        run: cd example/ios && RCT_NEW_ARCH_ENABLED=1 pod install
 
       - name: Use the current package sources in build
         run: cd example && npm run refresh-package

--- a/.github/workflows/ReactNativeSlider-CI.yml
+++ b/.github/workflows/ReactNativeSlider-CI.yml
@@ -109,16 +109,14 @@ jobs:
         with:
           path: |
             example/node_modules
-          key: ${{ hashFiles('./example/package-lock.json') }}-${{ hashFiles('./package/package-lock.json') }}
+            example/ios/Pods
+          key: ${{ hashFiles('./example/package-lock.json') }}-${{ hashFiles('./package/package-lock.json') }}-${{ hashFiles('./example/ios/Podfile.lock') }}
 
       - name: Install required dependencies on cache miss (npm)
         if: steps.cache-npm.outputs.cache-hit != 'true'
         run: |
           npm install
-
-      - name: Install pods
-        run: pod install --verbose
-        working-directory: example/ios
+          cd example/ios && pod install
 
       - name: Use the current package sources in build
         run: cd example && npm run refresh-package
@@ -148,16 +146,14 @@ jobs:
         with:
           path: |
             example/node_modules
-          key: ${{ hashFiles('./example/package-lock.json') }}-${{ hashFiles('./package/package-lock.json') }}
+            example/ios/Pods
+          key: ${{ hashFiles('./example/package-lock.json') }}-${{ hashFiles('./package/package-lock.json') }}-${{ hashFiles('./example/ios/Podfile.lock') }}
 
       - name: Install required dependencies on cache miss (npm)
         if: steps.cache-npm.outputs.cache-hit != 'true'
         run: |
           npm install
-
-      - name: Install pods
-        run: RCT_NEW_ARCH_ENABLED=1 pod install
-        working-directory: example/ios
+          cd example/ios && RCT_NEW_ARCH_ENABLED=1 pod install
 
       - name: Use the current package sources in build
         run: cd example && npm run refresh-package

--- a/.github/workflows/ReactNativeSlider-CI.yml
+++ b/.github/workflows/ReactNativeSlider-CI.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           cd example/ios && pod install
 
-      - name: Reinstall Pods
+      - name: Reinstall Pods only if using cached ones
         if: steps.cache-pods.outputs.cache-hit == 'true'
         run: cd example/ios && pod install
 
@@ -181,7 +181,7 @@ jobs:
         run: |
           cd example/ios && RCT_NEW_ARCH_ENABLED=1 pod install
 
-      - name: Reinstall Pods
+      - name: Reinstall Pods only if using cached ones
         if: steps.cache-pods.outputs.cache-hit == 'true'
         run: cd example/ios && RCT_NEW_ARCH_ENABLED=1 pod install
 


### PR DESCRIPTION
This pull request fixes issues with cached Pods that were unable to use after downloading from cache.
The fix is to reinstall downloaded Pods so that the Pods project will get reintegrated between different build and environments.