### PR TITLE
fix onValueChanges is called on programmatic value changes on Android

### DIFF
--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -108,7 +108,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
               new ReactSliderEvent(
                   seekbar.getId(),
                   ((ReactSlider)seekbar).toRealProgress(seekbar.getProgress()),
-                  !((ReactSlider)seekbar).isSliding()));
+                  false));
         }
       };
 

--- a/package/src/Slider.js
+++ b/package/src/Slider.js
@@ -258,7 +258,14 @@ const SliderComponent = (
 
   const onValueChangeEvent = onValueChange
     ? (event: Event) => {
-        onValueChange(event.nativeEvent.value);
+        let userEvent = true;
+        if (Platform.OS === 'android') {
+          // On Android there's a special flag telling us the user is
+          // dragging the slider.
+          userEvent =
+            event.nativeEvent.fromUser != null && event.nativeEvent.fromUser;
+        }
+        userEvent && onValueChange(event.nativeEvent.value);
       }
     : null;
 


### PR DESCRIPTION
Summary:
---------

Revert changes from https://github.com/callstack/react-native-slider/pull/367 to fix https://github.com/callstack/react-native-slider/issues/395

What https://github.com/callstack/react-native-slider/pull/367 trying to fix is not an issue actually. The onValueChange should be called only when user is dragging the slide and it is matching with the behaviour on iOS
