### PR TITLE
[Fabric] Fix hot reloading causing photo jumps

### DIFF
--- a/package/ios/RNCSliderComponentView.h
+++ b/package/ios/RNCSliderComponentView.h
@@ -7,6 +7,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^RNCLoadImageCompletionBlock)(NSError * _Nullable error, UIImage * _Nullable image);
+typedef void (^RNCLoadImageFailureBlock)();
 
 @interface RNCSliderComponentView : RCTViewComponentView
 

--- a/package/ios/RNCSliderComponentView.mm
+++ b/package/ios/RNCSliderComponentView.mm
@@ -191,43 +191,69 @@ using namespace facebook::react;
         [slider setAccessibilityIncrements:accessibilityIncrements];
     }
     if (oldScreenProps.thumbImage != newScreenProps.thumbImage) {
-        [self loadImageFromImageSource:newScreenProps.thumbImage completionBlock:^(NSError *error, UIImage *image) {
-            dispatch_async(dispatch_get_main_queue(), ^{
+        [self loadImageFromImageSource:newScreenProps.thumbImage
+            completionBlock:^(NSError *error, UIImage *image) {
+              dispatch_async(dispatch_get_main_queue(), ^{
                 [self->slider setThumbImage:image];
-            });
-        }];
-    }
-    if (oldScreenProps.trackImage != newScreenProps.trackImage) {
-        [self loadImageFromImageSource:newScreenProps.trackImage completionBlock:^(NSError *error, UIImage *image) {
-            dispatch_async(dispatch_get_main_queue(), ^{
+              });
+            }
+            failureBlock:^{
+              [self->slider setThumbImage:nil];
+            }];
+      }
+      if (oldScreenProps.trackImage != newScreenProps.trackImage) {
+        [self loadImageFromImageSource:newScreenProps.trackImage
+            completionBlock:^(NSError *error, UIImage *image) {
+              dispatch_async(dispatch_get_main_queue(), ^{
                 [self->slider setTrackImage:image];
-            });
-        }];
-    }
-    if (oldScreenProps.minimumTrackImage != newScreenProps.minimumTrackImage) {
-        [self loadImageFromImageSource:newScreenProps.minimumTrackImage completionBlock:^(NSError *error, UIImage *image) {
-            dispatch_async(dispatch_get_main_queue(), ^{
+              });
+            }
+            failureBlock:^{
+              [self->slider setTrackImage:nil];
+            }];
+      }
+      if (oldScreenProps.minimumTrackImage != newScreenProps.minimumTrackImage) {
+        [self loadImageFromImageSource:newScreenProps.minimumTrackImage
+            completionBlock:^(NSError *error, UIImage *image) {
+              dispatch_async(dispatch_get_main_queue(), ^{
                 [self->slider setMinimumTrackImage:image];
-            });
-        }];
-    }
-    if (oldScreenProps.maximumTrackImage != newScreenProps.maximumTrackImage) {
-        [self loadImageFromImageSource:newScreenProps.maximumTrackImage completionBlock:^(NSError *error, UIImage *image) {
-            dispatch_async(dispatch_get_main_queue(), ^{
+              });
+            }
+            failureBlock:^{
+              [self->slider setMinimumTrackImage:nil];
+            }];
+      }
+      if (oldScreenProps.maximumTrackImage != newScreenProps.maximumTrackImage) {
+        [self loadImageFromImageSource:newScreenProps.maximumTrackImage
+            completionBlock:^(NSError *error, UIImage *image) {
+              dispatch_async(dispatch_get_main_queue(), ^{
                 [self->slider setMaximumTrackImage:image];
-            });
-        }];
-    }
+              });
+            }
+            failureBlock:^{
+              [self->slider setMaximumTrackImage:nil];
+            }];
+      }
     [super updateProps:props oldProps:oldProps];
 }
 
 
 // TODO temporarily using bridge, workaround for https://github.com/reactwg/react-native-new-architecture/discussions/31#discussioncomment-2717047, rewrite when Meta comes with a solution.
-- (void)loadImageFromImageSource:(ImageSource)source completionBlock:(RNCLoadImageCompletionBlock)completionBlock
+- (void)loadImageFromImageSource:(ImageSource)source completionBlock:(RNCLoadImageCompletionBlock)completionBlock failureBlock:(RNCLoadImageFailureBlock)failureBlock
 {
     NSString *uri = [[NSString alloc] initWithUTF8String:source.uri.c_str()];
     if ((BOOL)uri.length) {
-        [[[RCTBridge currentBridge] moduleForName:@"ImageLoader"] loadImageWithURLRequest:NSURLRequestFromImageSource(source) size:CGSizeMake(source.size.width, source.size.height) scale:source.scale clipped:NO resizeMode:RCTResizeModeCover progressBlock:nil partialLoadBlock:nil completionBlock:completionBlock];
+        [[[RCTBridge currentBridge] moduleForName:@"ImageLoader"]
+         loadImageWithURLRequest:NSURLRequestFromImageSource(source)
+         size:CGSizeMake(source.size.width, source.size.height)
+         scale:source.scale
+         clipped:NO
+         resizeMode:RCTResizeModeCover
+         progressBlock:nil
+         partialLoadBlock:nil
+         completionBlock:completionBlock];
+    } else {
+        failureBlock();
     }
 }
 

--- a/package/ios/RNCSliderComponentView.mm
+++ b/package/ios/RNCSliderComponentView.mm
@@ -191,49 +191,45 @@ using namespace facebook::react;
         [slider setAccessibilityIncrements:accessibilityIncrements];
     }
     if (oldScreenProps.thumbImage != newScreenProps.thumbImage) {
-        [self loadImageFromImageSource:newScreenProps.thumbImage
-            completionBlock:^(NSError *error, UIImage *image) {
-              dispatch_async(dispatch_get_main_queue(), ^{
+        [self loadImageFromImageSource:newScreenProps.thumbImage completionBlock:^(NSError *error, UIImage *image) {
+            dispatch_async(dispatch_get_main_queue(), ^{
                 [self->slider setThumbImage:image];
-              });
-            }
-            failureBlock:^{
-              [self->slider setThumbImage:nil];
-            }];
-      }
-      if (oldScreenProps.trackImage != newScreenProps.trackImage) {
-        [self loadImageFromImageSource:newScreenProps.trackImage
-            completionBlock:^(NSError *error, UIImage *image) {
-              dispatch_async(dispatch_get_main_queue(), ^{
+            });
+        }
+        failureBlock:^{
+            [self->slider setThumbImage:nil];
+        }];
+    }
+    if (oldScreenProps.trackImage != newScreenProps.trackImage) {
+        [self loadImageFromImageSource:newScreenProps.trackImage completionBlock:^(NSError *error, UIImage *image) {
+            dispatch_async(dispatch_get_main_queue(), ^{
                 [self->slider setTrackImage:image];
-              });
-            }
-            failureBlock:^{
-              [self->slider setTrackImage:nil];
-            }];
-      }
-      if (oldScreenProps.minimumTrackImage != newScreenProps.minimumTrackImage) {
-        [self loadImageFromImageSource:newScreenProps.minimumTrackImage
-            completionBlock:^(NSError *error, UIImage *image) {
-              dispatch_async(dispatch_get_main_queue(), ^{
+            });
+        }
+        failureBlock:^{
+            [self->slider setTrackImage:nil];
+        }];
+    }
+    if (oldScreenProps.minimumTrackImage != newScreenProps.minimumTrackImage) {
+        [self loadImageFromImageSource:newScreenProps.minimumTrackImage completionBlock:^(NSError *error, UIImage *image) {
+            dispatch_async(dispatch_get_main_queue(), ^{
                 [self->slider setMinimumTrackImage:image];
-              });
-            }
-            failureBlock:^{
-              [self->slider setMinimumTrackImage:nil];
-            }];
-      }
-      if (oldScreenProps.maximumTrackImage != newScreenProps.maximumTrackImage) {
-        [self loadImageFromImageSource:newScreenProps.maximumTrackImage
-            completionBlock:^(NSError *error, UIImage *image) {
-              dispatch_async(dispatch_get_main_queue(), ^{
+            });
+        }
+        failureBlock:^{
+            [self->slider setMinimumTrackImage:nil];
+        }];
+    }
+    if (oldScreenProps.maximumTrackImage != newScreenProps.maximumTrackImage) {
+        [self loadImageFromImageSource:newScreenProps.maximumTrackImage completionBlock:^(NSError *error, UIImage *image) {
+            dispatch_async(dispatch_get_main_queue(), ^{
                 [self->slider setMaximumTrackImage:image];
-              });
-            }
-            failureBlock:^{
-              [self->slider setMaximumTrackImage:nil];
-            }];
-      }
+            });
+        }
+        failureBlock:^{
+            [self->slider setMaximumTrackImage:nil];
+        }];
+    }
     [super updateProps:props oldProps:oldProps];
 }
 
@@ -244,14 +240,14 @@ using namespace facebook::react;
     NSString *uri = [[NSString alloc] initWithUTF8String:source.uri.c_str()];
     if ((BOOL)uri.length) {
         [[[RCTBridge currentBridge] moduleForName:@"ImageLoader"]
-         loadImageWithURLRequest:NSURLRequestFromImageSource(source)
-         size:CGSizeMake(source.size.width, source.size.height)
-         scale:source.scale
-         clipped:NO
-         resizeMode:RCTResizeModeCover
-         progressBlock:nil
-         partialLoadBlock:nil
-         completionBlock:completionBlock];
+        loadImageWithURLRequest:NSURLRequestFromImageSource(source)
+        size:CGSizeMake(source.size.width, source.size.height)
+        scale:source.scale
+        clipped:NO
+        resizeMode:RCTResizeModeCover
+        progressBlock:nil
+        partialLoadBlock:nil
+        completionBlock:completionBlock];
     } else {
         failureBlock();
     }


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

While playing with the example app I've discovered weird bug that caused images (`trackImage`, `thumbImage` etc.) to change their place and jump around (while rendering multiple sliders).

Here is a recording of this issue: 

https://user-images.githubusercontent.com/52801365/183864276-6e528e4c-93ca-4901-b5b5-2b7a98c89b8e.mp4

Test Plan:
----------
CI / Manual tests
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->