### PR TITLE
Configure buildscript with gradle-plugin only for new arch

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -1,18 +1,20 @@
-buildscript {
-  repositories {
-    mavenCentral()
-    google()
-  }
-
-  dependencies {
-    classpath("com.android.tools.build:gradle:7.1.1")
-    classpath("com.facebook.react:react-native-gradle-plugin")
-    classpath("de.undercouch:gradle-download-task:5.0.1")
-  }
-}
-
 def isNewArchitectureEnabled() {
   return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
+}
+
+if (isNewArchitectureEnabled()) {
+  buildscript {
+    repositories {
+      mavenCentral()
+      google()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:7.1.1")
+      classpath("com.facebook.react:react-native-gradle-plugin")
+      classpath("de.undercouch:gradle-download-task:5.0.1")
+    }
+  }
 }
 
 apply plugin: 'com.android.library'
@@ -27,7 +29,6 @@ def getExtOrDefault(name) {
 def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['ReactNativeSlider_' + name]).toInteger()
 }
-
 
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')


### PR DESCRIPTION
This pull request fixes #415 
It avoids using dependencies that cannot be found for Android when building for older RN versions.

**How to test**
* Create new react native application with older version (v0.67, or v0.66)
* install latest (v4.3.0) Slider package,
* in node modules find the Slider and open build.gradle
./node_modules/@react-native-community/slider/android/build.gradle
* apply the changes done in this PR to the local project
* Build the app as usual
