### PR TITLE
[Fabric] Refactor events, remove unused code

### DIFF
--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderEvent.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderEvent.java
@@ -10,7 +10,7 @@ package com.reactnativecommunity.slider;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.Event;
-import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.uimanager.events.RCTModernEventEmitter;
 
 /**
  * Event emitted by a ReactSliderManager when user changes slider position.
@@ -46,9 +46,10 @@ public class ReactSliderEvent extends Event<ReactSliderEvent> {
   public short getCoalescingKey() {
     return 0;
   }
+
   @Override
-  public void dispatch(RCTEventEmitter rctEventEmitter) {
-    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  public void dispatchModern(RCTModernEventEmitter rctEventEmitter) {
+      rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
   }
 
   private WritableMap serializeEventData() {

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderEvent.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderEvent.java
@@ -49,7 +49,7 @@ public class ReactSliderEvent extends Event<ReactSliderEvent> {
 
   @Override
   public void dispatchModern(RCTModernEventEmitter rctEventEmitter) {
-      rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
   }
 
   private WritableMap serializeEventData() {

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManagerImpl.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManagerImpl.java
@@ -5,18 +5,11 @@ import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
 import android.os.Build;
-import android.view.View;
-import android.widget.SeekBar;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
-import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.yoga.YogaMeasureFunction;
-import com.facebook.yoga.YogaMeasureMode;
-import com.facebook.yoga.YogaMeasureOutput;
-import com.facebook.yoga.YogaNode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,41 +20,6 @@ import javax.annotation.Nullable;
 public class ReactSliderManagerImpl {
 
     public static final String REACT_CLASS = "RNCSlider";
-
-    public static class ReactSliderShadowNode extends LayoutShadowNode implements
-            YogaMeasureFunction {
-
-        private int mWidth;
-        private int mHeight;
-        private boolean mMeasured;
-
-        public ReactSliderShadowNode() {
-            initMeasureFunction();
-        }
-
-        private void initMeasureFunction() {
-            setMeasureFunction(this);
-        }
-
-        @Override
-        public long measure(
-                YogaNode node,
-                float width,
-                YogaMeasureMode widthMode,
-                float height,
-                YogaMeasureMode heightMode) {
-            if (!mMeasured) {
-                SeekBar reactSlider = new ReactSlider(getThemedContext(), null);
-                final int spec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
-                reactSlider.measure(spec, spec);
-                mWidth = reactSlider.getMeasuredWidth();
-                mHeight = reactSlider.getMeasuredHeight();
-                mMeasured = true;
-            }
-
-            return YogaMeasureOutput.make(mWidth, mHeight);
-        }
-    }
 
     public static ReactSlider createViewInstance(ThemedReactContext context) {
         ReactSlider slider = new ReactSlider(context, null);

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlidingCompleteEvent.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlidingCompleteEvent.java
@@ -10,7 +10,7 @@ package com.reactnativecommunity.slider;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.Event;
-import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.uimanager.events.RCTModernEventEmitter;
 
 /**
  * Event emitted when the user finishes dragging the slider.
@@ -46,7 +46,7 @@ public class ReactSlidingCompleteEvent extends Event<ReactSlidingCompleteEvent> 
     }
 
     @Override
-    public void dispatch(RCTEventEmitter rctEventEmitter) {
+    public void dispatchModern(RCTModernEventEmitter rctEventEmitter) {
         rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
     }
 

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlidingStartEvent.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlidingStartEvent.java
@@ -10,7 +10,7 @@ package com.reactnativecommunity.slider;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.Event;
-import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.uimanager.events.RCTModernEventEmitter;
 
 /**
  * Event emitted when the user starts dragging the slider.
@@ -46,7 +46,7 @@ public class ReactSlidingStartEvent extends Event<ReactSlidingStartEvent> {
     }
 
     @Override
-    public void dispatch(RCTEventEmitter rctEventEmitter) {
+    public void dispatchModern(RCTModernEventEmitter rctEventEmitter) {
         rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
     }
 

--- a/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -6,8 +6,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.common.MapBuilder;
-import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerHelper;
@@ -83,16 +81,6 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
   @Override
   public String getName() {
     return ReactSliderManagerImpl.REACT_CLASS;
-  }
-
-  @Override
-  public LayoutShadowNode createShadowNodeInstance() {
-    return new ReactSliderManagerImpl.ReactSliderShadowNode();
-  }
-
-  @Override
-  public Class getShadowNodeClass() {
-    return ReactSliderManagerImpl.ReactSliderShadowNode.class;
   }
 
   @Override

--- a/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -4,7 +4,6 @@ import android.widget.SeekBar;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -12,7 +11,13 @@ import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import java.util.Map;
+import android.view.View;
 import javax.annotation.Nullable;
+
+import com.facebook.yoga.YogaMeasureFunction;
+import com.facebook.yoga.YogaMeasureMode;
+import com.facebook.yoga.YogaMeasureOutput;
+import com.facebook.yoga.YogaNode;
 
 /**
  * Manages instances of {@code ReactSlider}.
@@ -60,15 +65,50 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
   public String getName() {
     return ReactSliderManagerImpl.REACT_CLASS;
   }
+  
+  public static class ReactSliderShadowNode extends LayoutShadowNode implements
+            YogaMeasureFunction {
+
+        private int mWidth;
+        private int mHeight;
+        private boolean mMeasured;
+
+        public ReactSliderShadowNode() {
+            initMeasureFunction();
+        }
+
+        private void initMeasureFunction() {
+            setMeasureFunction(this);
+        }
+
+        @Override
+        public long measure(
+                YogaNode node,
+                float width,
+                YogaMeasureMode widthMode,
+                float height,
+                YogaMeasureMode heightMode) {
+            if (!mMeasured) {
+                SeekBar reactSlider = new ReactSlider(getThemedContext(), null);
+                final int spec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
+                reactSlider.measure(spec, spec);
+                mWidth = reactSlider.getMeasuredWidth();
+                mHeight = reactSlider.getMeasuredHeight();
+                mMeasured = true;
+            }
+
+            return YogaMeasureOutput.make(mWidth, mHeight);
+        }
+    }
 
   @Override
   public LayoutShadowNode createShadowNodeInstance() {
-    return new ReactSliderManagerImpl.ReactSliderShadowNode();
+    return new ReactSliderShadowNode();
   }
 
   @Override
   public Class getShadowNodeClass() {
-    return ReactSliderManagerImpl.ReactSliderShadowNode.class;
+    return ReactSliderShadowNode.class;
   }
 
   @Override

--- a/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -66,40 +66,40 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
     return ReactSliderManagerImpl.REACT_CLASS;
   }
   
-  public static class ReactSliderShadowNode extends LayoutShadowNode implements
-            YogaMeasureFunction {
+  static class ReactSliderShadowNode extends LayoutShadowNode implements
+      YogaMeasureFunction {
 
-        private int mWidth;
-        private int mHeight;
-        private boolean mMeasured;
+    private int mWidth;
+    private int mHeight;
+    private boolean mMeasured;
 
-        public ReactSliderShadowNode() {
-            initMeasureFunction();
-        }
-
-        private void initMeasureFunction() {
-            setMeasureFunction(this);
-        }
-
-        @Override
-        public long measure(
-                YogaNode node,
-                float width,
-                YogaMeasureMode widthMode,
-                float height,
-                YogaMeasureMode heightMode) {
-            if (!mMeasured) {
-                SeekBar reactSlider = new ReactSlider(getThemedContext(), null);
-                final int spec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
-                reactSlider.measure(spec, spec);
-                mWidth = reactSlider.getMeasuredWidth();
-                mHeight = reactSlider.getMeasuredHeight();
-                mMeasured = true;
-            }
-
-            return YogaMeasureOutput.make(mWidth, mHeight);
-        }
+    private ReactSliderShadowNode() {
+      initMeasureFunction();
     }
+
+    private void initMeasureFunction() {
+      setMeasureFunction(this);
+    }
+
+    @Override
+    public long measure(
+        YogaNode node,
+        float width,
+        YogaMeasureMode widthMode,
+        float height,
+        YogaMeasureMode heightMode) {
+      if (!mMeasured) {
+        SeekBar reactSlider = new ReactSlider(getThemedContext(), null);
+        final int spec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
+        reactSlider.measure(spec, spec);
+        mWidth = reactSlider.getMeasuredWidth();
+        mHeight = reactSlider.getMeasuredHeight();
+        mMeasured = true;
+      }
+
+      return YogaMeasureOutput.make(mWidth, mHeight);
+    }
+  }
 
   @Override
   public LayoutShadowNode createShadowNodeInstance() {


### PR DESCRIPTION
According to [this discussion](https://github.com/reactwg/react-native-new-architecture/discussions/70#discussioncomment-3429973), ShadowNodes are not used in the new architecture so I moved it back to old arch. 

Regarding events: 

> `RCTModernEventEmitter` is a transitional replacement for `RCTEventEmitter` that works with Fabric and non-Fabric renderers. `RCTEventEmitter` works with Fabric as well, but there are negative perf implications and it should be avoided.

Source: [react-native source code](https://github.dev/facebook/react-native/blob/e0a71fc7b5cb8c264000147099be5b2575931193/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/RCTModernEventEmitter.java#L7)

Test Plan:
----------
CI

---

This pull request fixes #412 