### PR TITLE
feature: Add slide limit to iOS and Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ To use this library you need to ensure you are using the correct version of Reac
 | `maximumValue` | Initial maximum value of the slider.<br/>Default value is 1. | number | No | |
 | `minimumTrackTintColor` | The color used for the track to the left of the button.<br/>Overrides the default blue gradient image on iOS. | [color](https://reactnative.dev/docs/colors) | No | |
 | `minimumValue` | Initial minimum value of the slider.<br/>Default value is 0. | number | No | |
+| `limit` | Slide limit. The user won't be able to slide past this limit.<br/>It is 0 when disabled. Default value is 0. | number | No | |
 | `onSlidingStart` | Callback that is called when the user picks up the slider.<br/>The initial value is passed as an argument to the callback handler. | function | No | |
 | `onSlidingComplete` | Callback that is called when the user releases the slider, regardless if the value has changed.<br/>The current value is passed as an argument to the callback handler. | function | No | |
 | `onValueChange` | Callback continuously called while the user is dragging the slider. | function | No | |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ To use this library you need to ensure you are using the correct version of Reac
 | `maximumValue` | Initial maximum value of the slider.<br/>Default value is 1. | number | No | |
 | `minimumTrackTintColor` | The color used for the track to the left of the button.<br/>Overrides the default blue gradient image on iOS. | [color](https://reactnative.dev/docs/colors) | No | |
 | `minimumValue` | Initial minimum value of the slider.<br/>Default value is 0. | number | No | |
-| `limit` | Slide limit. The user won't be able to slide past this limit.<br/>It is 0 when disabled. Default value is 0. | number | No | |
+| `lowerLimit` | Slide lower limit. The user won't be able to slide below this limit. | number | No | |
+| `upperLimit` | Slide upper limit. The user won't be able to slide above this limit. | number | No | |
 | `onSlidingStart` | Callback that is called when the user picks up the slider.<br/>The initial value is passed as an argument to the callback handler. | function | No | |
 | `onSlidingComplete` | Callback that is called when the user releases the slider, regardless if the value has changed.<br/>The current value is passed as an argument to the callback handler. | function | No | |
 | `onValueChange` | Callback continuously called while the user is dragging the slider. | function | No | |

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ To use this library you need to ensure you are using the correct version of Reac
 | `maximumValue` | Initial maximum value of the slider.<br/>Default value is 1. | number | No | |
 | `minimumTrackTintColor` | The color used for the track to the left of the button.<br/>Overrides the default blue gradient image on iOS. | [color](https://reactnative.dev/docs/colors) | No | |
 | `minimumValue` | Initial minimum value of the slider.<br/>Default value is 0. | number | No | |
-| `lowerLimit` | Slide lower limit. The user won't be able to slide below this limit. | number | No | |
-| `upperLimit` | Slide upper limit. The user won't be able to slide above this limit. | number | No | |
+| `lowerLimit` | Slide lower limit. The user won't be able to slide below this limit. | number | No | Android, iOS |
+| `upperLimit` | Slide upper limit. The user won't be able to slide above this limit. | number | No | Android, iOS |
 | `onSlidingStart` | Callback that is called when the user picks up the slider.<br/>The initial value is passed as an argument to the callback handler. | function | No | |
 | `onSlidingComplete` | Callback that is called when the user releases the slider, regardless if the value has changed.<br/>The current value is passed as an argument to the callback handler. | function | No | |
 | `onValueChange` | Callback continuously called while the user is dragging the slider. | function | No | |

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -40,9 +40,6 @@
       "name": "@react-native-community/slider",
       "version": "4.3.2",
       "license": "MIT",
-      "dependencies": {
-        "@types/react-test-renderer": "^18.0.0"
-      },
       "devDependencies": {
         "@babel/cli": "^7.8.4",
         "@babel/core": "^7.12.9",
@@ -52,6 +49,7 @@
         "@react-native-community/eslint-config": "2.0.0",
         "@types/jest": "^28.1.8",
         "@types/react-native": "^0.69.5",
+        "@types/react-test-renderer": "^18.0.0",
         "babel-jest": "^26.6.3",
         "babel-plugin-module-resolver": "3.1.3",
         "copyfiles": "^2.4.1",

--- a/example/src/Examples.tsx
+++ b/example/src/Examples.tsx
@@ -3,7 +3,7 @@ import {Text, View, StyleSheet} from 'react-native';
 import Slider, {SliderProps} from '@react-native-community/slider';
 
 const SliderExample = (props: SliderProps) => {
-  const [value, setValue] = useState(0);
+  const [value, setValue] = useState(props.value ?? 0);
   return (
     <View>
       <Text style={styles.text}>{value && +value.toFixed(3)}</Text>
@@ -11,6 +11,7 @@ const SliderExample = (props: SliderProps) => {
         step={0.5}
         style={styles.slider}
         {...props}
+        value={value}
         onValueChange={setValue}
       />
     </View>
@@ -95,6 +96,14 @@ export const examples = [
     title: 'step: 0.25, tap to seek on iOS',
     render(): React.ReactElement {
       return <SliderExample step={0.25} tapToSeek={true} />;
+    },
+  },
+  {
+    title: 'Limit to 70',
+    render() {
+      return (
+        <SliderExample step={1} value={30} maximumValue={100} limit={70} />
+      );
     },
   },
   {

--- a/example/src/Examples.tsx
+++ b/example/src/Examples.tsx
@@ -99,10 +99,32 @@ export const examples = [
     },
   },
   {
-    title: 'Limit to 70',
+    title: 'Limit on positive values [30, 80]',
     render() {
       return (
-        <SliderExample step={1} value={30} maximumValue={100} limit={70} />
+        <SliderExample
+          step={1}
+          value={40}
+          minimumValue={0}
+          maximumValue={120}
+          lowerLimit={30}
+          upperLimit={80}
+        />
+      );
+    },
+  },
+  {
+    title: 'Limit on negative values [-70, -20]',
+    render() {
+      return (
+        <SliderExample
+          step={1}
+          value={-30}
+          minimumValue={-80}
+          maximumValue={0}
+          lowerLimit={-70}
+          upperLimit={-20}
+        />
       );
     },
   },

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -66,6 +66,12 @@ public class ReactSlider extends AppCompatSeekBar {
 
   private List<String> mAccessibilityIncrements;
 
+  /** Real limit value based on min and max values. This comes from props */
+  private double mRealLimit = 0;
+
+  /** Limit based on progress from 0..100 */
+  private int mLimit = 0;
+
   public ReactSlider(Context context, @Nullable AttributeSet attrs) {
     super(context, attrs);
     I18nUtil sharedI18nUtilInstance = I18nUtil.getInstance();
@@ -100,6 +106,15 @@ public class ReactSlider extends AppCompatSeekBar {
   /* package */ void setStep(double step) {
     mStep = step;
     updateAll();
+  }
+
+  /* package */ void setRealLimit(double value) {
+    mRealLimit = value;
+    updateAll();
+  }
+
+  int getLimit() {
+    return this.mLimit;
   }
 
   boolean isSliding() {
@@ -185,8 +200,14 @@ public class ReactSlider extends AppCompatSeekBar {
     if (mStep == 0) {
       mStepCalculated = (mMaxValue - mMinValue) / (double) DEFAULT_TOTAL_STEPS;
     }
+    updateLimit();
     setMax(getTotalSteps());
     updateValue();
+  }
+
+  /** Update limit based on props limit, max and min */
+  private void updateLimit() {
+    mLimit = (int) Math.round((mRealLimit - mMinValue) / (mMaxValue - mMinValue) * getTotalSteps());
   }
 
   /** Update value only (optimization in case only value is set). */

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -69,14 +69,14 @@ public class ReactSlider extends AppCompatSeekBar {
   /** Real limit value based on min and max values. This comes from props */
   private double mRealLowerLimit = Long.MIN_VALUE;
 
-  /** Limit based on progress from 0..100 */
-  private int mLowerLimit = 0;
+  /** Lower limit based on the SeekBar progress 0..total steps */
+  private int mLowerLimit;
 
   /** Real limit value based on min and max values. This comes from props */
   private double mRealUpperLimit = Long.MAX_VALUE;
 
-  /** Limit based on progress from 0..100 */
-  private int mUpperLimit = 100;
+  /** Upper limit based on the SeekBar progress 0..total steps */
+  private int mUpperLimit;
 
   public ReactSlider(Context context, @Nullable AttributeSet attrs) {
     super(context, attrs);

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -67,10 +67,16 @@ public class ReactSlider extends AppCompatSeekBar {
   private List<String> mAccessibilityIncrements;
 
   /** Real limit value based on min and max values. This comes from props */
-  private double mRealLimit = 0;
+  private double mRealLowerLimit = Long.MIN_VALUE;
 
   /** Limit based on progress from 0..100 */
-  private int mLimit = 0;
+  private int mLowerLimit = 0;
+
+  /** Real limit value based on min and max values. This comes from props */
+  private double mRealUpperLimit = Long.MAX_VALUE;
+
+  /** Limit based on progress from 0..100 */
+  private int mUpperLimit = 100;
 
   public ReactSlider(Context context, @Nullable AttributeSet attrs) {
     super(context, attrs);
@@ -108,13 +114,22 @@ public class ReactSlider extends AppCompatSeekBar {
     updateAll();
   }
 
-  /* package */ void setRealLimit(double value) {
-    mRealLimit = value;
-    updateAll();
+  /* package */ void setLowerLimit(double value) {
+    mRealLowerLimit = value;
+    updateLowerLimit();
   }
 
-  int getLimit() {
-    return this.mLimit;
+  /* package */ void setUpperLimit(double value) {
+    mRealUpperLimit = value;
+    updateUpperLimit();
+  }
+
+  int getLowerLimit() {
+    return this.mLowerLimit;
+  }
+
+  int getUpperLimit() {
+    return this.mUpperLimit;
   }
 
   boolean isSliding() {
@@ -200,14 +215,22 @@ public class ReactSlider extends AppCompatSeekBar {
     if (mStep == 0) {
       mStepCalculated = (mMaxValue - mMinValue) / (double) DEFAULT_TOTAL_STEPS;
     }
-    updateLimit();
     setMax(getTotalSteps());
+    updateLowerLimit();
+    updateUpperLimit();
     updateValue();
   }
 
   /** Update limit based on props limit, max and min */
-  private void updateLimit() {
-    mLimit = (int) Math.round((mRealLimit - mMinValue) / (mMaxValue - mMinValue) * getTotalSteps());
+  private void updateLowerLimit() {
+    double limit = Math.max(mRealLowerLimit, mMinValue);
+    mLowerLimit = (int) Math.round((limit - mMinValue) / (mMaxValue - mMinValue) * getTotalSteps());
+  }
+
+  /** Update limit based on props limit, max and min */
+  private void updateUpperLimit() {
+    double limit = Math.min(mRealUpperLimit, mMaxValue);
+    mUpperLimit = (int) Math.round((limit - mMinValue) / (mMaxValue - mMinValue) * getTotalSteps());
   }
 
   /** Update value only (optimization in case only value is set). */

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManagerImpl.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManagerImpl.java
@@ -52,11 +52,11 @@ public class ReactSliderManagerImpl {
         view.setMaxValue(value);
     }
 
-    public static void setLowerLimit(ReactSlider view, float value) {
+    public static void setLowerLimit(ReactSlider view, double value) {
         view.setLowerLimit(value);
     }
 
-    public static void setUpperLimit(ReactSlider view, float value) {
+    public static void setUpperLimit(ReactSlider view, double value) {
         view.setUpperLimit(value);
     }
 

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManagerImpl.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManagerImpl.java
@@ -52,6 +52,10 @@ public class ReactSliderManagerImpl {
         view.setMaxValue(value);
     }
 
+    public static void setLimit(ReactSlider view, float value) {
+        view.setRealLimit(value);
+    }
+
     public static void setStep(ReactSlider view, float value) {
         view.setStep(value);
     }

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManagerImpl.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManagerImpl.java
@@ -52,8 +52,12 @@ public class ReactSliderManagerImpl {
         view.setMaxValue(value);
     }
 
-    public static void setLimit(ReactSlider view, float value) {
-        view.setRealLimit(value);
+    public static void setLowerLimit(ReactSlider view, float value) {
+        view.setLowerLimit(value);
+    }
+
+    public static void setUpperLimit(ReactSlider view, float value) {
+        view.setUpperLimit(value);
     }
 
     public static void setStep(ReactSlider view, float value) {

--- a/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -40,10 +40,17 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
           new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar seekbar, int progress, boolean fromUser) {
+              ReactSlider slider = (ReactSlider)seekbar;
+
+              if(slider.getLimit() > 0 && progress > slider.getLimit()) {
+                progress = slider.getLimit();
+                seekbar.setProgress(progress);
+              }
+
               ReactContext reactContext = (ReactContext) seekbar.getContext();
               int reactTag = seekbar.getId();
               UIManagerHelper.getEventDispatcherForReactTag(reactContext, reactTag)
-                      .dispatchEvent(new ReactSliderEvent(reactTag, ((ReactSlider)seekbar).toRealProgress(progress), fromUser));
+                      .dispatchEvent(new ReactSliderEvent(reactTag, slider.toRealProgress(progress), fromUser));
             }
 
             @Override
@@ -152,6 +159,11 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
   @ReactProp(name = "accessibilityIncrements")
   public void setAccessibilityIncrements(ReactSlider view, ReadableArray accessibilityIncrements) {
     ReactSliderManagerImpl.setAccessibilityIncrements(view, accessibilityIncrements);
+  }
+
+  @ReactProp(name = "limit", defaultFloat = 0f)
+  public void setLimit(ReactSlider view, float value) {
+    ReactSliderManagerImpl.setLimit(view, value);
   }
 
   @Override

--- a/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -42,8 +42,13 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
             public void onProgressChanged(SeekBar seekbar, int progress, boolean fromUser) {
               ReactSlider slider = (ReactSlider)seekbar;
 
-              if(slider.getLimit() > 0 && progress > slider.getLimit()) {
-                progress = slider.getLimit();
+              if(progress < slider.getLowerLimit()) {
+                progress = slider.getLowerLimit();
+                seekbar.setProgress(progress);
+              }
+
+              if(progress > slider.getUpperLimit()) {
+                progress = slider.getUpperLimit();
                 seekbar.setProgress(progress);
               }
 
@@ -161,9 +166,14 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
     ReactSliderManagerImpl.setAccessibilityIncrements(view, accessibilityIncrements);
   }
 
-  @ReactProp(name = "limit", defaultFloat = 0f)
-  public void setLimit(ReactSlider view, float value) {
-    ReactSliderManagerImpl.setLimit(view, value);
+  @ReactProp(name = "lowerLimit")
+  public void setLowerLimit(ReactSlider view, float value) {
+    ReactSliderManagerImpl.setLowerLimit(view, value);
+  }
+
+  @ReactProp(name = "upperLimit")
+  public void setUpperLimit(ReactSlider view, float value) {
+    ReactSliderManagerImpl.setUpperLimit(view, value);
   }
 
   @Override

--- a/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -45,9 +45,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
               if(progress < slider.getLowerLimit()) {
                 progress = slider.getLowerLimit();
                 seekbar.setProgress(progress);
-              }
-
-              if(progress > slider.getUpperLimit()) {
+              } else if (progress > slider.getUpperLimit()) {
                 progress = slider.getUpperLimit();
                 seekbar.setProgress(progress);
               }

--- a/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -33,9 +33,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
               if(progress < slider.getLowerLimit()) {
                 progress = slider.getLowerLimit();
                 seekbar.setProgress(progress);
-              }
-
-              if(progress > slider.getUpperLimit()) {
+              } else if(progress > slider.getUpperLimit()) {
                 progress = slider.getUpperLimit();
                 seekbar.setProgress(progress);
               }

--- a/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -28,11 +28,18 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
           new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar seekbar, int progress, boolean fromUser) {
+              ReactSlider slider = (ReactSlider)seekbar;
+
+              if(slider.getLimit() > 0 && progress > slider.getLimit()) {
+                progress = slider.getLimit();
+                seekbar.setProgress(progress);
+              }
+
               ReactContext reactContext = (ReactContext) seekbar.getContext();
               reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
                       new ReactSliderEvent(
                               seekbar.getId(),
-                              ((ReactSlider)seekbar).toRealProgress(progress), fromUser));
+                              slider.toRealProgress(progress), fromUser));
             }
 
             @Override
@@ -134,6 +141,11 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
   @ReactProp(name = "maximumValue", defaultFloat = 1f)
   public void setMaximumValue(ReactSlider view, float value) {
     ReactSliderManagerImpl.setMaximumValue(view, value);
+  }
+
+  @ReactProp(name = "limit", defaultFloat = 0f)
+  public void setLimit(ReactSlider view, float value) {
+    ReactSliderManagerImpl.setLimit(view, value);
   }
 
   @ReactProp(name = "step", defaultFloat = 0f)

--- a/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -30,8 +30,13 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
             public void onProgressChanged(SeekBar seekbar, int progress, boolean fromUser) {
               ReactSlider slider = (ReactSlider)seekbar;
 
-              if(slider.getLimit() > 0 && progress > slider.getLimit()) {
-                progress = slider.getLimit();
+              if(progress < slider.getLowerLimit()) {
+                progress = slider.getLowerLimit();
+                seekbar.setProgress(progress);
+              }
+
+              if(progress > slider.getUpperLimit()) {
+                progress = slider.getUpperLimit();
                 seekbar.setProgress(progress);
               }
 
@@ -143,9 +148,14 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
     ReactSliderManagerImpl.setMaximumValue(view, value);
   }
 
-  @ReactProp(name = "limit", defaultFloat = 0f)
-  public void setLimit(ReactSlider view, float value) {
-    ReactSliderManagerImpl.setLimit(view, value);
+  @ReactProp(name = "lowerLimit")
+  public void setLowerLimit(ReactSlider view, float value) {
+    ReactSliderManagerImpl.setLowerLimit(view, value);
+  }
+
+  @ReactProp(name = "upperLimit")
+  public void setUpperLimit(ReactSlider view, float value) {
+    ReactSliderManagerImpl.setUpperLimit(view, value);
   }
 
   @ReactProp(name = "step", defaultFloat = 0f)

--- a/package/babel.config.json
+++ b/package/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["module:metro-react-native-babel-preset"]
+  "presets": ["@babel/preset-typescript", "module:metro-react-native-babel-preset"]
 }

--- a/package/babel.config.json
+++ b/package/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-typescript", "module:metro-react-native-babel-preset"]
+  "presets": ["module:metro-react-native-babel-preset"]
 }

--- a/package/ios/RNCSlider.h
+++ b/package/ios/RNCSlider.h
@@ -18,6 +18,7 @@
 @property (nonatomic, assign) float step;
 @property (nonatomic, assign) float lastValue;
 @property (nonatomic, assign) bool isSliding;
+@property (nonatomic, assign) float limit;
 
 @property (nonatomic, strong) UIImage *trackImage;
 @property (nonatomic, strong) UIImage *minimumTrackImage;

--- a/package/ios/RNCSlider.h
+++ b/package/ios/RNCSlider.h
@@ -18,7 +18,9 @@
 @property (nonatomic, assign) float step;
 @property (nonatomic, assign) float lastValue;
 @property (nonatomic, assign) bool isSliding;
-@property (nonatomic, assign) float limit;
+
+@property (nonatomic, assign) float lowerLimit;
+@property (nonatomic, assign) float upperLimit;
 
 @property (nonatomic, strong) UIImage *trackImage;
 @property (nonatomic, strong) UIImage *minimumTrackImage;

--- a/package/ios/RNCSliderComponentView.h
+++ b/package/ios/RNCSliderComponentView.h
@@ -18,7 +18,9 @@ typedef void (^RNCLoadImageFailureBlock)();
 @property (nonatomic, assign) float step;
 @property (nonatomic, assign) float lastValue;
 @property (nonatomic, assign) bool isSliding;
-@property (nonatomic, assign) float limit;
+
+@property (nonatomic, assign) float lowerLimit;
+@property (nonatomic, assign) float upperLimit;
 
 @property (nonatomic, strong) UIImage *trackImage;
 @property (nonatomic, strong) UIImage *minimumTrackImage;

--- a/package/ios/RNCSliderComponentView.h
+++ b/package/ios/RNCSliderComponentView.h
@@ -18,6 +18,7 @@ typedef void (^RNCLoadImageFailureBlock)();
 @property (nonatomic, assign) float step;
 @property (nonatomic, assign) float lastValue;
 @property (nonatomic, assign) bool isSliding;
+@property (nonatomic, assign) float limit;
 
 @property (nonatomic, strong) UIImage *trackImage;
 @property (nonatomic, strong) UIImage *minimumTrackImage;

--- a/package/ios/RNCSliderComponentView.mm
+++ b/package/ios/RNCSliderComponentView.mm
@@ -118,6 +118,11 @@ using namespace facebook::react;
 {
     float value = [sender discreteValue:sender.value];
     
+    if (sender.limit > 0 && value > sender.limit) {
+        value = sender.limit;
+        [sender setValue:value animated:NO];
+    }
+
     if(!sender.isSliding) {
         [sender setValue:value animated:NO];
     }
@@ -162,6 +167,9 @@ using namespace facebook::react;
     }
     if (oldScreenProps.maximumValue != newScreenProps.maximumValue) {
         [slider setMaximumValue:newScreenProps.maximumValue];
+    }
+    if (oldScreenProps.limit != newScreenProps.limit) {
+        slider.limit = newScreenProps.limit;
     }
     if (oldScreenProps.tapToSeek != newScreenProps.tapToSeek) {
         slider.tapToSeek = newScreenProps.tapToSeek;

--- a/package/ios/RNCSliderComponentView.mm
+++ b/package/ios/RNCSliderComponentView.mm
@@ -120,9 +120,7 @@ using namespace facebook::react;
     if (value < sender.lowerLimit) {
         value = sender.lowerLimit;
         [sender setValue:value animated:NO];
-    }
-        
-    if (value > sender.upperLimit) {
+    } else if (value > sender.upperLimit) {
         value = sender.upperLimit;
         [sender setValue:value animated:NO];
     }

--- a/package/ios/RNCSliderComponentView.mm
+++ b/package/ios/RNCSliderComponentView.mm
@@ -14,7 +14,6 @@
 #import "RCTFabricComponentsPlugins.h"
 #import "RNCSlider.h"
 
-
 using namespace facebook::react;
 
 @interface RNCSliderComponentView () <RCTRNCSliderViewProtocol>
@@ -118,8 +117,13 @@ using namespace facebook::react;
 {
     float value = [sender discreteValue:sender.value];
     
-    if (sender.limit > 0 && value > sender.limit) {
-        value = sender.limit;
+    if (value < sender.lowerLimit) {
+        value = sender.lowerLimit;
+        [sender setValue:value animated:NO];
+    }
+        
+    if (value > sender.upperLimit) {
+        value = sender.upperLimit;
         [sender setValue:value animated:NO];
     }
 
@@ -168,8 +172,11 @@ using namespace facebook::react;
     if (oldScreenProps.maximumValue != newScreenProps.maximumValue) {
         [slider setMaximumValue:newScreenProps.maximumValue];
     }
-    if (oldScreenProps.limit != newScreenProps.limit) {
-        slider.limit = newScreenProps.limit;
+    if (oldScreenProps.lowerLimit != newScreenProps.lowerLimit) {
+        slider.lowerLimit = newScreenProps.lowerLimit;
+    }
+    if (oldScreenProps.upperLimit != newScreenProps.upperLimit) {
+        slider.upperLimit = newScreenProps.upperLimit;
     }
     if (oldScreenProps.tapToSeek != newScreenProps.tapToSeek) {
         slider.tapToSeek = newScreenProps.tapToSeek;

--- a/package/ios/RNCSliderManager.m
+++ b/package/ios/RNCSliderManager.m
@@ -87,8 +87,13 @@ static void RNCSendSliderEvent(RNCSlider *sender, BOOL continuous, BOOL isSlidin
 {
   float value = [sender discreteValue:sender.value];
 
-  if (sender.limit > 0 && value > sender.limit) {
-      value = sender.limit;
+  if (value < sender.lowerLimit) {
+      value = sender.lowerLimit;
+      [sender setValue:value animated:NO];
+  }
+    
+  if (value > sender.upperLimit) {
+      value = sender.upperLimit;
       [sender setValue:value animated:NO];
   }
 
@@ -149,6 +154,8 @@ RCT_EXPORT_VIEW_PROPERTY(minimumTrackImage, UIImage);
 RCT_EXPORT_VIEW_PROPERTY(maximumTrackImage, UIImage);
 RCT_EXPORT_VIEW_PROPERTY(minimumValue, float);
 RCT_EXPORT_VIEW_PROPERTY(maximumValue, float);
+RCT_EXPORT_VIEW_PROPERTY(lowerLimit, float);
+RCT_EXPORT_VIEW_PROPERTY(upperLimit, float);
 RCT_EXPORT_VIEW_PROPERTY(minimumTrackTintColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(maximumTrackTintColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(onRNCSliderValueChange, RCTBubblingEventBlock);
@@ -160,7 +167,6 @@ RCT_EXPORT_VIEW_PROPERTY(inverted, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(tapToSeek, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(accessibilityUnits, NSString);
 RCT_EXPORT_VIEW_PROPERTY(accessibilityIncrements, NSArray);
-RCT_EXPORT_VIEW_PROPERTY(limit, float);
 
 RCT_CUSTOM_VIEW_PROPERTY(disabled, BOOL, RNCSlider)
 {

--- a/package/ios/RNCSliderManager.m
+++ b/package/ios/RNCSliderManager.m
@@ -87,6 +87,11 @@ static void RNCSendSliderEvent(RNCSlider *sender, BOOL continuous, BOOL isSlidin
 {
   float value = [sender discreteValue:sender.value];
 
+  if (sender.limit > 0 && value > sender.limit) {
+      value = sender.limit;
+      [sender setValue:value animated:NO];
+  }
+
   if(!sender.isSliding) {
     [sender setValue:value animated:NO];
   }
@@ -155,6 +160,7 @@ RCT_EXPORT_VIEW_PROPERTY(inverted, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(tapToSeek, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(accessibilityUnits, NSString);
 RCT_EXPORT_VIEW_PROPERTY(accessibilityIncrements, NSArray);
+RCT_EXPORT_VIEW_PROPERTY(limit, float);
 
 RCT_CUSTOM_VIEW_PROPERTY(disabled, BOOL, RNCSlider)
 {

--- a/package/ios/RNCSliderManager.m
+++ b/package/ios/RNCSliderManager.m
@@ -90,9 +90,7 @@ static void RNCSendSliderEvent(RNCSlider *sender, BOOL continuous, BOOL isSlidin
   if (value < sender.lowerLimit) {
       value = sender.lowerLimit;
       [sender setValue:value animated:NO];
-  }
-    
-  if (value > sender.upperLimit) {
+  } else if (value > sender.upperLimit) {
       value = sender.upperLimit;
       [sender setValue:value animated:NO];
   }

--- a/package/src/RNCSliderNativeComponent.ts
+++ b/package/src/RNCSliderNativeComponent.ts
@@ -38,6 +38,7 @@ export interface NativeProps extends ViewProps {
   thumbTintColor?: ColorValue;
   trackImage?: ImageSource;
   value?: Float;
+  limit?: Float;
 }
 
 export default codegenNativeComponent<NativeProps>(

--- a/package/src/RNCSliderNativeComponent.ts
+++ b/package/src/RNCSliderNativeComponent.ts
@@ -38,7 +38,8 @@ export interface NativeProps extends ViewProps {
   thumbTintColor?: ColorValue;
   trackImage?: ImageSource;
   value?: Float;
-  limit?: Float;
+  lowerLimit?: Float;
+  upperLimit?: Float;
 }
 
 export default codegenNativeComponent<NativeProps>(

--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -16,6 +16,9 @@ import type {ImageSource} from 'react-native/Libraries/Image/ImageSource';
 
 import type {Ref} from 'react';
 
+const LIMIT_MIN_VALUE = Number.MIN_SAFE_INTEGER;
+const LIMIT_MAX_VALUE = Number.MAX_SAFE_INTEGER;
+
 type Event = NativeSyntheticEvent<
   Readonly<{
     value: number;
@@ -99,6 +102,16 @@ type Props = ViewProps &
      * Initial maximum value of the slider. Default value is 1.
      */
     maximumValue?: number;
+
+    /**
+     * The lower limit value of the slider. The user won't be able to slide below this limit.
+     */
+    lowerLimit?: number;
+
+    /**
+     * The upper limit value of the slider. The user won't be able to slide above this limit.
+     */
+    upperLimit?: number;
 
     /**
      * The color used for the track to the left of the button.
@@ -221,9 +234,21 @@ const SliderComponent = (
       }
     : null;
 
+  const lowerLimit =
+    !!localProps.lowerLimit || localProps.lowerLimit === 0
+      ? localProps.lowerLimit
+      : LIMIT_MIN_VALUE;
+
+  const upperLimit =
+    !!localProps.upperLimit || localProps.upperLimit === 0
+      ? localProps.upperLimit
+      : LIMIT_MAX_VALUE;
+
   return (
     <RCTSliderNativeComponent
       {...localProps}
+      lowerLimit={lowerLimit}
+      upperLimit={upperLimit}
       accessibilityState={_accessibilityState}
       thumbImage={
         Platform.OS === 'web'
@@ -256,6 +281,8 @@ SliderWithRef.defaultProps = {
   step: 0,
   inverted: false,
   tapToSeek: false,
+  lowerLimit: LIMIT_MIN_VALUE,
+  upperLimit: LIMIT_MAX_VALUE,
 };
 
 let styles = StyleSheet.create(

--- a/package/src/__tests__/Slider.test.tsx
+++ b/package/src/__tests__/Slider.test.tsx
@@ -52,6 +52,8 @@ describe('<Slider />', () => {
           thumbTintColor={'green'}
           onSlidingComplete={() => {}}
           onValueChange={() => {}}
+          lowerLimit={0}
+          upperLimit={1}
         />,
       )
       .toJSON();

--- a/package/src/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/package/src/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`<Slider /> accessibilityState disabled sets disabled={true} 1`] = `
   disabled={true}
   enabled={false}
   inverted={false}
+  lowerLimit={-9007199254740991}
   maximumValue={1}
   minimumValue={0}
   onChange={null}
@@ -26,6 +27,7 @@ exports[`<Slider /> accessibilityState disabled sets disabled={true} 1`] = `
     }
   }
   tapToSeek={false}
+  upperLimit={9007199254740991}
   value={0}
 />
 `;
@@ -40,6 +42,7 @@ exports[`<Slider /> disabled prop overrides accessibilityState.disabled 1`] = `
   disabled={true}
   enabled={false}
   inverted={false}
+  lowerLimit={-9007199254740991}
   maximumValue={1}
   minimumValue={0}
   onChange={null}
@@ -56,6 +59,7 @@ exports[`<Slider /> disabled prop overrides accessibilityState.disabled 1`] = `
     }
   }
   tapToSeek={false}
+  upperLimit={9007199254740991}
   value={0}
 />
 `;
@@ -70,6 +74,7 @@ exports[`<Slider /> disabled prop overrides accessibilityState.enabled 1`] = `
   disabled={false}
   enabled={true}
   inverted={false}
+  lowerLimit={-9007199254740991}
   maximumValue={1}
   minimumValue={0}
   onChange={null}
@@ -86,6 +91,7 @@ exports[`<Slider /> disabled prop overrides accessibilityState.enabled 1`] = `
     }
   }
   tapToSeek={false}
+  upperLimit={9007199254740991}
   value={0}
 />
 `;
@@ -95,6 +101,7 @@ exports[`<Slider /> renders a slider with custom props 1`] = `
   disabled={false}
   enabled={true}
   inverted={false}
+  lowerLimit={0}
   maximumTrackTintColor="red"
   maximumValue={2}
   minimumTrackTintColor="blue"
@@ -114,6 +121,7 @@ exports[`<Slider /> renders a slider with custom props 1`] = `
   }
   tapToSeek={false}
   thumbTintColor="green"
+  upperLimit={1}
   value={0.5}
 />
 `;
@@ -128,6 +136,7 @@ exports[`<Slider /> renders disabled slider 1`] = `
   disabled={true}
   enabled={false}
   inverted={false}
+  lowerLimit={-9007199254740991}
   maximumValue={1}
   minimumValue={0}
   onChange={null}
@@ -144,6 +153,7 @@ exports[`<Slider /> renders disabled slider 1`] = `
     }
   }
   tapToSeek={false}
+  upperLimit={9007199254740991}
   value={0}
 />
 `;
@@ -153,6 +163,7 @@ exports[`<Slider /> renders enabled slider 1`] = `
   disabled={false}
   enabled={true}
   inverted={false}
+  lowerLimit={-9007199254740991}
   maximumValue={1}
   minimumValue={0}
   onChange={null}
@@ -169,6 +180,7 @@ exports[`<Slider /> renders enabled slider 1`] = `
     }
   }
   tapToSeek={false}
+  upperLimit={9007199254740991}
   value={0}
 />
 `;

--- a/package/typings/index.d.ts
+++ b/package/typings/index.d.ts
@@ -77,10 +77,14 @@ export interface SliderProps
   maximumValue?: number;
 
   /**
-   * The limit value of the slider. The user won't be able to slide pass this limit.
-   * Default value is 0.
+   * The lower limit value of the slider. The user won't be able to slide below this limit.
    */
-  limit?: number;
+  lowerLimit?: number;
+
+  /**
+   * The upper limit value of the slider. The user won't be able to slide above this limit.
+   */
+  upperLimit?: number;
 
   /**
    * The color used for the track to the left of the button.

--- a/package/typings/index.d.ts
+++ b/package/typings/index.d.ts
@@ -77,6 +77,12 @@ export interface SliderProps
   maximumValue?: number;
 
   /**
+   * The limit value of the slider. The user won't be able to slide pass this limit.
+   * Default value is 0.
+   */
+  limit?: number;
+
+  /**
    * The color used for the track to the left of the button.
    * Overrides the default blue gradient image.
    */
@@ -162,6 +168,7 @@ export interface SliderProps
  * A component used to select a single value from a range of values.
  */
 declare class SliderComponent extends React.Component<SliderProps> {}
-declare const SliderBase: ReactNative.Constructor<ReactNative.NativeMethods> & typeof SliderComponent;
+declare const SliderBase: ReactNative.Constructor<ReactNative.NativeMethods> &
+  typeof SliderComponent;
 export default class Slider extends SliderBase {}
 export type SliderIOS = Slider;


### PR DESCRIPTION
Summary:
---------
Feature to add slide limit. This will prevent sliding past the limit.

![Sep-26-2022 12-36-29](https://user-images.githubusercontent.com/3791120/192332627-acf82176-fea7-49fc-8ceb-bdcf07ead869.gif)


- Added new `upperLimit` and `lowerLimit` props to Slider.
- Implemented `upperLimit` and `lowerLimit` on iOS and Android for fabric and paper.

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->