### PR TITLE
Copy over correct documentation for accessibilityIncrements

### DIFF
--- a/package/typings/index.d.ts
+++ b/package/typings/index.d.ts
@@ -145,10 +145,10 @@ export interface SliderProps
   accessibilityUnits?: string;
 
   /**
-   * A string of one or more words to be announced by the screen reader.
-   * Otherwise, it will announce the value as a percentage.
-   * Requires passing a value to `accessibilityIncrements` to work correctly.
-   * Should be a plural word, as singular units will be handled.
+   * An array of values that represent the different increments displayed
+   * by the slider. All the values passed into this prop must be strings.
+   * Requires passing a value to `accessibilityUnits` to work correctly.
+   * The number of elements must be the same as `maximumValue`.
    */
   accessibilityIncrements?: Array<string>;
 


### PR DESCRIPTION
Summary:
---------

Found myself wanting to use the `accessibilityUnits` and `accessibilityIncrements` props to enhance screen reader experience in the app I am working on. When trying to figure out what data-type should be passed to `accessibilityIncrements` I realised that the TypeScript documentation was just a copy of the `accessibilityUnits` documentation. The correct documentation for `accessibilityIncrements` was however written in the JavaScript implementation, so I copied it over to the TypeScript documentation.


Test Plan:
----------

Only documentation changes, no testing required