### PR TITLE
Replace dispatchModern() calls with getEventData()

### DIFF
--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderEvent.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderEvent.java
@@ -7,10 +7,10 @@
 
 package com.reactnativecommunity.slider;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.Event;
-import com.facebook.react.uimanager.events.RCTModernEventEmitter;
 
 /**
  * Event emitted by a ReactSliderManager when user changes slider position.
@@ -47,9 +47,10 @@ public class ReactSliderEvent extends Event<ReactSliderEvent> {
     return 0;
   }
 
+  @Nullable
   @Override
-  public void dispatchModern(RCTModernEventEmitter rctEventEmitter) {
-    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  protected WritableMap getEventData() {
+    return serializeEventData();
   }
 
   private WritableMap serializeEventData() {

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlidingCompleteEvent.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlidingCompleteEvent.java
@@ -7,10 +7,10 @@
 
 package com.reactnativecommunity.slider;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.Event;
-import com.facebook.react.uimanager.events.RCTModernEventEmitter;
 
 /**
  * Event emitted when the user finishes dragging the slider.
@@ -45,9 +45,10 @@ public class ReactSlidingCompleteEvent extends Event<ReactSlidingCompleteEvent> 
         return false;
     }
 
+    @Nullable
     @Override
-    public void dispatchModern(RCTModernEventEmitter rctEventEmitter) {
-        rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+    protected WritableMap getEventData() {
+        return serializeEventData();
     }
 
     private WritableMap serializeEventData() {

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlidingStartEvent.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlidingStartEvent.java
@@ -7,10 +7,10 @@
 
 package com.reactnativecommunity.slider;
 
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.Event;
-import com.facebook.react.uimanager.events.RCTModernEventEmitter;
 
 /**
  * Event emitted when the user starts dragging the slider.
@@ -45,9 +45,10 @@ public class ReactSlidingStartEvent extends Event<ReactSlidingStartEvent> {
         return false;
     }
 
+    @Nullable
     @Override
-    public void dispatchModern(RCTModernEventEmitter rctEventEmitter) {
-        rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+    protected WritableMap getEventData() {
+        return serializeEventData();
     }
 
     private WritableMap serializeEventData() {


### PR DESCRIPTION
Summary:
---------

Over on https://github.com/callstack/react-native-slider/issues/437, we see issues on Android...sometimes. Long story short, Reanimated intercepts event dispatching, and it calls the method removed in #422. (there's some more detail in [this](https://github.com/callstack/react-native-slider/issues/437#issuecomment-1282577509) comment)

We can see in the stacktrace that `dispatchModern()` isn't being called when dispatched via Reanimated:

<img width="531" alt="Screen Shot 2022-10-18 at 3 06 06 pm" src="https://user-images.githubusercontent.com/33126/196474758-c3be67d3-fede-45d6-a920-54479eb49aaf.png">

The [react-native source](https://github.com/facebook/react-native/blob/f6cfcc3fc9e0b13d854f3c5295b67794507706c6/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/Event.java#L168-L172) describes the fix: don't override `dispatch()` and `dispatchModern()`, but simply override `getEventData()`. This PR does that, and seems to be working well!

(Sidebar: if we decide to keep the `dispatchModern()` override, we should update the implementation to use the actual modern dispatcher instead of the old dispatcher. See [here](https://github.com/facebook/react-native/blob/f6cfcc3fc9e0b13d854f3c5295b67794507706c6/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/Event.java#L211-L227) for how that should look.)

This pull request fixes #437 

Test Plan:
----------

I have a repro on [this](https://github.com/notjosh/react-native-slider/tree/crashy) branch (it crashes on boot, no repro steps necessary), and we can use [this](https://github.com/notjosh/react-native-slider/tree/fixy) branch to verify that the change works with Reanimated.

Note: It's possible that other libs than Reanimated have other ways of calling this, so there might be a side effect to implementing `getEventData()`, but I _think_ it should be pretty safe.