### PR TITLE
Run the CI on pull request

### DIFF
--- a/.github/workflows/ReactNativeSlider-CI.yml
+++ b/.github/workflows/ReactNativeSlider-CI.yml
@@ -1,6 +1,6 @@
 name: ReactNativeSlider-CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   install:


### PR DESCRIPTION
This pull request adds launching the CI on pull request.
The `pull_request` was added to the list of events triggering the full CI.

**NOTE:** This PR was made from fork to test whether creating this PR will trigger the CI on the original upstream.