### PR TITLE
fix: remove redundant "enabled" property

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ You can also do this manually by:
 In order to use the new architecture some extra steps are needed. 
 #### iOS 
 - Install pods with new arch flag inside `example/ios` folder: `RCT_NEW_ARCH_ENABLED=1 pod install`
-- Run `npm run ios` in `example/ios` folder
+- Run `npm run example-ios`
 
 #### Android 
 - Set `newArchEnabled` to true inside `example/android/gradle.properties`

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ In order to use the new architecture some extra steps are needed.
 
 #### Android 
 - Set `newArchEnabled` to true inside `example/android/gradle.properties`
-- Run `npm run example-android` _(first run might fail, try to run it again)_
+- Run `npm run example-android`
 
 <details>
 <summary>

--- a/README.md
+++ b/README.md
@@ -146,11 +146,11 @@ You can also do this manually by:
 In order to use the new architecture some extra steps are needed. 
 #### iOS 
 - Install pods with new arch flag inside `example/ios` folder: `RCT_NEW_ARCH_ENABLED=1 pod install`
-- Run `npm run example-ios`
+- Run `npm run ios` in `example/ios` folder
 
 #### Android 
 - Set `newArchEnabled` to true inside `example/android/gradle.properties`
-- Run `npm run example-android`
+- Run `npm run example-android` (first run might fail, try to run it again)
 
 <details>
 <summary>

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ In order to use the new architecture some extra steps are needed.
 
 #### Android 
 - Set `newArchEnabled` to true inside `example/android/gradle.properties`
-- Run `npm run example-android` (first run might fail, try to run it again)
+- Run `npm run example-android` _(first run might fail, try to run it again)_
 
 <details>
 <summary>

--- a/example/src/Examples.tsx
+++ b/example/src/Examples.tsx
@@ -182,7 +182,6 @@ export const examples = [
   },
   {
     title: 'Disabled slider',
-    platform: 'android',
     render() {
       return <SliderExample disabled value={0.6} />;
     },

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManagerImpl.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManagerImpl.java
@@ -56,8 +56,8 @@ public class ReactSliderManagerImpl {
         view.setStep(value);
     }
 
-    public static void setEnabled(ReactSlider view, boolean enabled) {
-        view.setEnabled(enabled);
+    public static void setDisabled(ReactSlider view, boolean disabled) {
+        view.setEnabled(!disabled);
     }
 
     public static void setThumbTintColor(ReactSlider view, Integer color) {

--- a/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -177,10 +177,6 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
 
   // these props are not available on Android, however we must override their setters
   @Override
-  @ReactProp(name = "disabled")
-  public void setDisabled(ReactSlider view, boolean disabled) {}
-
-  @Override
   public void setMinimumTrackImage(ReactSlider view, @Nullable ReadableMap readableMap) {}
 
   @Override

--- a/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -89,9 +89,9 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
   }
 
   @Override
-  @ReactProp(name = ViewProps.ENABLED, defaultBoolean = true)
-  public void setEnabled(ReactSlider view, boolean enabled) {
-    ReactSliderManagerImpl.setEnabled(view, enabled);
+  @ReactProp(name = "disabled", defaultBoolean = false)
+  public void setDisabled(ReactSlider view, boolean disabled) {
+    ReactSliderManagerImpl.setDisabled(view, disabled);
   }
 
   @Override

--- a/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -116,9 +116,9 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
     return ReactSliderManagerImpl.createViewInstance(context);
   }
 
-  @ReactProp(name = ViewProps.ENABLED, defaultBoolean = true)
-  public void setEnabled(ReactSlider view, boolean enabled) {
-    ReactSliderManagerImpl.setEnabled(view, enabled);
+  @ReactProp(name = "disabled", defaultBoolean = false)
+  public void setDisabled(ReactSlider view, boolean disabled) {
+    ReactSliderManagerImpl.setDisabled(view, disabled);
   }
 
   @ReactProp(name = "value", defaultFloat = 0f)

--- a/package/src/RNCSliderNativeComponent.ts
+++ b/package/src/RNCSliderNativeComponent.ts
@@ -18,7 +18,6 @@ export interface NativeProps extends ViewProps {
   accessibilityUnits?: string;
   accessibilityIncrements?: ReadonlyArray<string>;
   disabled?: WithDefault<boolean, false>;
-  enabled?: WithDefault<boolean, true>;
   inverted?: WithDefault<boolean, false>;
   vertical?: WithDefault<boolean, false>;
   tapToSeek?: WithDefault<boolean, false>;

--- a/package/src/RNCSliderNativeComponent.web.tsx
+++ b/package/src/RNCSliderNativeComponent.web.tsx
@@ -32,7 +32,7 @@ export interface Props {
   thumbStyle: ViewStyle;
   style: ViewStyle;
   inverted: boolean;
-  enabled: boolean;
+  disabled: boolean;
   trackHeight: number;
   thumbSize: number;
   onRNCSliderSlidingStart: (value: number) => void;
@@ -53,7 +53,7 @@ const RCTSliderWebComponent = React.forwardRef(
       thumbStyle = {},
       style = {},
       inverted = false,
-      enabled = true,
+      disabled = false,
       trackHeight = 4,
       thumbSize = 20,
       onRNCSliderSlidingStart = (_: number) => {},
@@ -273,8 +273,8 @@ const RCTSliderWebComponent = React.forwardRef(
         accessible={true}
         accessibilityRole={'adjustable'}
         style={containerStyle}
-        onStartShouldSetResponder={() => enabled}
-        onMoveShouldSetResponder={() => enabled}
+        onStartShouldSetResponder={() => !disabled}
+        onMoveShouldSetResponder={() => !disabled}
         onResponderGrant={() => onSlidingStart(value)}
         onResponderRelease={onTouchEnd}
         onResponderMove={onMove}

--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -238,7 +238,6 @@ const SliderComponent = (
       onRNCSliderSlidingStart={onSlidingStartEvent}
       onRNCSliderSlidingComplete={onSlidingCompleteEvent}
       onRNCSliderValueChange={onValueChangeEvent}
-      enabled={!_disabled}
       disabled={_disabled}
       onStartShouldSetResponder={() => true}
       onResponderTerminationRequest={() => false}

--- a/package/src/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/package/src/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`<Slider /> accessibilityState disabled sets disabled={true} 1`] = `
     }
   }
   disabled={true}
-  enabled={false}
   inverted={false}
   maximumValue={1}
   minimumValue={0}
@@ -38,7 +37,6 @@ exports[`<Slider /> disabled prop overrides accessibilityState.disabled 1`] = `
     }
   }
   disabled={true}
-  enabled={false}
   inverted={false}
   maximumValue={1}
   minimumValue={0}
@@ -68,7 +66,6 @@ exports[`<Slider /> disabled prop overrides accessibilityState.enabled 1`] = `
     }
   }
   disabled={false}
-  enabled={true}
   inverted={false}
   maximumValue={1}
   minimumValue={0}
@@ -93,7 +90,6 @@ exports[`<Slider /> disabled prop overrides accessibilityState.enabled 1`] = `
 exports[`<Slider /> renders a slider with custom props 1`] = `
 <RNCSlider
   disabled={false}
-  enabled={true}
   inverted={false}
   maximumTrackTintColor="red"
   maximumValue={2}
@@ -126,7 +122,6 @@ exports[`<Slider /> renders disabled slider 1`] = `
     }
   }
   disabled={true}
-  enabled={false}
   inverted={false}
   maximumValue={1}
   minimumValue={0}
@@ -151,7 +146,6 @@ exports[`<Slider /> renders disabled slider 1`] = `
 exports[`<Slider /> renders enabled slider 1`] = `
 <RNCSlider
   disabled={false}
-  enabled={true}
   inverted={false}
   maximumValue={1}
   minimumValue={0}


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

Removing redundant "enabled" property as discussed in https://github.com/callstack/react-native-slider/pull/424#discussion_r966294006 and documented in https://github.com/callstack/react-native-slider/issues/426

Fixed some instructions in README as well:
- iOS: "`npm run ios` in `example/ios` folder" instead of "`npm run example-ios`" <-- the other command runs `pod-install` which installs pods with old arch
- Android: adding note that after changing settings to new architecture, first run fails for some reason and other ones are running fine 🤷 

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Enabled "disabled" example for all platforms, so run the examples and test it out :)

iOS:
![simulator_screenshot_0E3EFDC2-4119-4CD8-B8F7-7FC738E92C2E](https://user-images.githubusercontent.com/15640932/198659952-2da82c67-3035-45ea-9bcc-28d5231dd4e1.png)

Android:
![Screenshot_1666969491](https://user-images.githubusercontent.com/15640932/198667372-5dc2a928-b953-4cc4-a227-cbdb26f896ce.png)

