### PR TITLE
Refactor the workflows events triggers

### DIFF
--- a/.github/workflows/ReactNativeSlider-CI.yml
+++ b/.github/workflows/ReactNativeSlider-CI.yml
@@ -1,6 +1,11 @@
 name: ReactNativeSlider-CI
 
-on: [push, pull_request]
+on:
+  pull_request
+  push:
+    branches:
+      - 'main'
+      - 'release/**'
 
 jobs:
   install:

--- a/.github/workflows/ReactNativeSlider-CI.yml
+++ b/.github/workflows/ReactNativeSlider-CI.yml
@@ -1,11 +1,12 @@
 name: ReactNativeSlider-CI
 
 on:
-  pull_request
   push:
     branches:
       - 'main'
       - 'release/**'
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   install:


### PR DESCRIPTION
This pull request changes the way the events are triggered for the CI workflow.
It makes the CI to run for specific cases of PR, **or** for pushes made only to specific branches: `main` and `release/`.
The main reasoning behind this is to:
avoid multiple triggers of the same workflow
save some minutes for unnecessary runs.