### PR TITLE
fix(web): invalidate position on ancestor scroll

### DIFF
--- a/example-web/src/Examples.tsx
+++ b/example-web/src/Examples.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 // @ts-ignore
-import {Text, View, StyleSheet} from 'react-native';
+import {Text, View, StyleSheet, ScrollView} from 'react-native';
 // @ts-ignore
 import Slider, {SliderProps} from '@react-native-community/slider';
 
@@ -199,6 +199,31 @@ export const examples: Props[] = [
     platform: 'android',
     render() {
       return <SliderExample disabled value={0.6} />;
+    },
+  },
+  {
+    title: 'Slider in horizontal scroll view',
+    render() {
+      return (
+        <ScrollView
+          horizontal
+          style={{
+            paddingVertical: 50,
+            borderStyle: 'dotted',
+            borderWidth: 1,
+            flexDirection: 'row',
+            width: 300,
+          }}
+          contentContainerStyle={{ overflowX: 'scroll' }}
+        >
+          <View style={{ width: 400, paddingLeft: 100 }}>
+            <SliderExample maximumValue={100} />
+            <Text style={{ textAlign: 'right', width: 200 }}>
+              Scroll right, then slide ➔
+            </Text>
+          </View>
+        </ScrollView>
+      );
     },
   },
 ];

--- a/package/src/RNCSliderNativeComponent.web.tsx
+++ b/package/src/RNCSliderNativeComponent.web.tsx
@@ -150,9 +150,9 @@ const RCTSliderWebComponent = React.forwardRef(
         containerPositionInvalidated.current = true;
       };
       const onDocumentScroll = (e: Event) => {
+        const isAlreadyInvalidated = !containerPositionInvalidated.current;
         if (
-          // Avoid all other checks if already invalidated
-          !containerPositionInvalidated.current &&
+          isAlreadyInvalidated &&
           containerRef.current &&
           // @ts-ignore
           e.target.contains(containerRef.current)


### PR DESCRIPTION
Summary:
---------

Fixes #471.

As there is no native way to listen for changes to `getBoundingClientRect()`, the web implementation of Slider must cache and try to correctly invalidate the measurements. The code already does this on layout and when the viewport is resized, but not when the slider's bounding rect changes due to scrolling. This PR registers a capturing `scroll` event handler on `document` and invalidates the cache when an ancestor of the slider scrolls. This is probably not airtight (see this [StackOverflow discussion](https://stackoverflow.com/questions/40251082/an-event-or-observer-for-changes-to-getboundingclientrect)) but is AFAICT correct.

For performance, it may be worth experimenting with unregistering the `scroll` (and `resize`) listener once the cache has been invalidated - this would avoid calling O(sliders on page) handlers on every frame while scrolling. This is a potentially more invasive change to Slider so I am publishing the PR without it.

Test Plan:
----------

Added an example to `example-web` and tested it manually (see video).

https://user-images.githubusercontent.com/2246565/209722872-273ba577-6ae8-44b3-957c-6455fbc93827.mov
