### PR TITLE
Avoid sending 'onValueChanged' on programmatic slide event

### DIFF
--- a/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -39,10 +39,17 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
               }
 
               ReactContext reactContext = (ReactContext) seekbar.getContext();
-              reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
-                      new ReactSliderEvent(
-                              seekbar.getId(),
-                              slider.toRealProgress(progress), fromUser));
+              if(fromUser) {
+                reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
+                  new ReactSliderEvent(
+                    seekbar.getId(),
+                    slider.toRealProgress(progress), fromUser));
+              } else {
+                reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
+                  new ReactSlidingCompleteEvent(
+                    seekbar.getId(),
+                    ((ReactSlider)seekbar).toRealProgress(seekbar.getProgress())));
+              }
             }
 
             @Override


### PR DESCRIPTION
This pull request fixes #395 

It prevents from sending the `onValueChanged` event if it **does not** come from user's interaction.
Instead - it sends the `onSlidingComplete` event when the programmatic change happens so it's clear when value is updated without actually changing it via sliding.

This pull request has been tested against comparison between iOS and Android platforms. Please see the attached demo recorded during final testing:

https://user-images.githubusercontent.com/70535775/212943723-fe9e9005-4128-4e45-a72e-7dca8a1b5107.mov


