### PR TITLE
fix(types): utility type removed from RN 0.71

### DIFF
--- a/package/typings/index.d.ts
+++ b/package/typings/index.d.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import * as ReactNative from 'react-native';
 
+type Constructor<T> = new (...args: any[]) => T;
+
 type SliderReferenceType =
   | (React.MutableRefObject<SliderRef> & React.LegacyRef<Slider>)
   | undefined;
@@ -172,7 +174,7 @@ export interface SliderProps
  * A component used to select a single value from a range of values.
  */
 declare class SliderComponent extends React.Component<SliderProps> {}
-declare const SliderBase: ReactNative.Constructor<ReactNative.NativeMethods> &
+declare const SliderBase: Constructor<ReactNative.NativeMethods> &
   typeof SliderComponent;
 export default class Slider extends SliderBase {}
 export type SliderIOS = Slider;


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->
Updating to react native 0.71, TypeScript errors on this library. The utility type `Constructor` is private in latest typings. Using this export degrades to `any` type.

`JSX element class does not support attributes because it does not have a 'props' property.`

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

`npx tsc` runs clean after making this change on a RN 0.71 app.