### PR TITLE
Check for existing cached dependencies before installing new

### DIFF
--- a/.github/workflows/ReactNativeSlider-CI.yml
+++ b/.github/workflows/ReactNativeSlider-CI.yml
@@ -17,15 +17,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Restore all the packages
-        run: npm install
-
-      - name: Cache
-        uses: actions/cache@v3.0.5
+      - name: Cache node modules
+        id: cache-package-npm
+        uses: actions/cache@v3.0.7
+        env:
+          cache-name: cached-ci-npm-deps
         with:
           path: ./package/node_modules
           key: ${{ hashFiles('./package/package.json') }}
 
+      - name: Install required dependencies on cache miss (npm)
+        if: steps.cache-package-npm.outputs.cache-hit != 'true'
+        run: |
+          npm install
 
   verify-package-sources:
     name: Lint the sources
@@ -37,7 +41,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Pull npm dependencies
-        uses: actions/cache@v3.0.5
+        uses: actions/cache@v3.0.7
         with:
           path: ./package/node_modules
           key: ${{ hashFiles('./package/package.json') }}
@@ -59,7 +63,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Pull npm dependencies
-        uses: actions/cache@v3.0.5
+        uses: actions/cache@v3.0.7
         with:
           path: ./package/node_modules
           key: ${{ hashFiles('./package/package.json') }}


### PR DESCRIPTION
This pull request fixes an issue in CI workflow of missing check for existing deps before installing new.
This saves a bit of time for init steps in CI.