### PR TITLE
Fix: Avoid passing `value` prop if it's not a valid number

### DIFF
--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -234,7 +234,8 @@ const SliderComponent = (
       }
     : null;
 
-  const value = Number.isNaN(props.value) || !props.value ? undefined : props.value;
+  const value =
+    Number.isNaN(props.value) || !props.value ? undefined : props.value;
 
   const lowerLimit =
     !!localProps.lowerLimit || localProps.lowerLimit === 0

--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -234,6 +234,8 @@ const SliderComponent = (
       }
     : null;
 
+  const value = Number.isNaN(props.value) || !props.value ? undefined : props.value;
+
   const lowerLimit =
     !!localProps.lowerLimit || localProps.lowerLimit === 0
       ? localProps.lowerLimit
@@ -247,6 +249,7 @@ const SliderComponent = (
   return (
     <RCTSliderNativeComponent
       {...localProps}
+      value={value}
       lowerLimit={lowerLimit}
       upperLimit={upperLimit}
       accessibilityState={_accessibilityState}

--- a/package/src/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/package/src/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`<Slider /> accessibilityState disabled sets disabled={true} 1`] = `
   }
   tapToSeek={false}
   upperLimit={9007199254740991}
-  value={0}
 />
 `;
 
@@ -58,7 +57,6 @@ exports[`<Slider /> disabled prop overrides accessibilityState.disabled 1`] = `
   }
   tapToSeek={false}
   upperLimit={9007199254740991}
-  value={0}
 />
 `;
 
@@ -89,7 +87,6 @@ exports[`<Slider /> disabled prop overrides accessibilityState.enabled 1`] = `
   }
   tapToSeek={false}
   upperLimit={9007199254740991}
-  value={0}
 />
 `;
 
@@ -149,7 +146,6 @@ exports[`<Slider /> renders disabled slider 1`] = `
   }
   tapToSeek={false}
   upperLimit={9007199254740991}
-  value={0}
 />
 `;
 
@@ -175,6 +171,5 @@ exports[`<Slider /> renders enabled slider 1`] = `
   }
   tapToSeek={false}
   upperLimit={9007199254740991}
-  value={0}
 />
 `;


### PR DESCRIPTION
This pull request fixes #345
It prevents the `value` prop to be sent to Slider when it is not a valid number.

The fix was tested using the repro scenario from the original issue, recording below:

https://github.com/callstack/react-native-slider/assets/70535775/fe817cbf-0f65-4646-884b-634c7d0105a4

