### PR TITLE
Update the compatibility table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ To use this library you need to ensure you are using the correct version of Reac
 
 | `@react-native-community/slider` version | Required React Native Version |
 | ---------------------------------------- | ----------------------------- |
+| `4.3.0`                                  | `>=0.64`                      |
 | `4.x.x`                                  | `>=0.60`; `>=0.62` (on Windows);  |
 | `3.1.x`                                  | `>=0.60`                      |
 | `2.x.x`                                  | `>= 0.60`                     |


### PR DESCRIPTION
This pull request closes #447 and #452 
It updates the compatibility table in README so that users/developers will be aware that using Slider after introducing new architecture should be done with react native version of at least 0.64.
