### PR TITLE
feat: Add support for RN 0.72

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -31,6 +31,7 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
+  namespace 'com.reactnativecommunity.slider'
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
 


### PR DESCRIPTION
Adds `namespace` to `build.gradle` (this is required by Gradle 8, which RN 0.72 uses)
