### PR TITLE
Prevent from tapping beyond or outside of limits

### DIFF
--- a/package/ios/RNCSliderComponentView.mm
+++ b/package/ios/RNCSliderComponentView.mm
@@ -74,13 +74,19 @@ using namespace facebook::react;
     if (!slider.tapToSeek) {
         return;
     }
-    
+
     CGPoint touchPoint = [gesture locationInView:slider];
     float rangeWidth = slider.maximumValue - slider.minimumValue;
     float sliderPercent = touchPoint.x / slider.bounds.size.width;
     slider.lastValue = slider.value;
     float value = slider.minimumValue + (rangeWidth * sliderPercent);
-    
+
+    if (value < slider.lowerLimit) {
+        value = slider.lowerLimit;
+    } else if (value > slider.upperLimit) {
+        value = slider.upperLimit;
+    }
+
     [slider setValue:[slider discreteValue:value] animated: YES];
     
     std::dynamic_pointer_cast<const RNCSliderEventEmitter>(_eventEmitter)

--- a/package/ios/RNCSliderManager.m
+++ b/package/ios/RNCSliderManager.m
@@ -61,6 +61,12 @@ RCT_EXPORT_MODULE()
   slider.lastValue = slider.value;
   float value = slider.minimumValue + (rangeWidth * sliderPercent);
 
+  if (value < slider.lowerLimit) {
+      value = slider.lowerLimit;
+  } else if (value > slider.upperLimit) {
+      value = slider.upperLimit;
+  }
+
   [slider setValue:[slider discreteValue:value] animated: YES];
 
   if (slider.onRNCSliderSlidingStart) {


### PR DESCRIPTION
This pull request fixes #469 for iOS platform, where tapping (not dragging) would allow to set the `value` outside of the `lowerLimit` and `upperLimit`.

https://github.com/callstack/react-native-slider/assets/70535775/ea358b9e-c8d8-4a79-a197-096f4adcddd6

