### PR TITLE
Update react-native-slider.podspec to use install_module_dependencies 

### DIFF
--- a/package/react-native-slider.podspec
+++ b/package/react-native-slider.podspec
@@ -17,22 +17,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/callstack/react-native-slider.git", :tag => "v#{s.version}" }
   s.source_files = "ios/**/*.{h,m,mm}"
 
-  s.dependency 'React-Core'
-
-  # This guard prevent to install the dependencies when we run `pod install` in the old architecture.
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-        "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
-
-    s.dependency "React-RCTFabric"
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
-  end
+  install_modules_dependencies(s)
 end


### PR DESCRIPTION
Summary:
---------

Fixes #529. More details: https://reactnative.dev/docs/the-new-architecture/backward-compatibility-turbomodules.


Test Plan:
----------

Verify that the package compiles after enabling the new architecture 