### PR TITLE
fix(android): android gradle plugin 8 compatibility

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -34,8 +34,8 @@ android {
 
   def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
   // Check AGP version for backward compatibility w/react-native versions still on gradle plugin 6
-  def major = parsed[0].toInteger()
-  def minor = parsed[1].toInteger()
+  def major = agpVersion[0].toInteger()
+  def minor = agpVersion[1].toInteger()
   if ((major == 7 && minor >= 3) || major >= 8) {
     namespace "com.reactnativecommunity.slider"
     buildFeatures {

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -32,7 +32,7 @@ def getExtOrIntegerDefault(name) {
 
 android {
 
-  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
   // Check AGP version for backward compatibility w/react-native versions still on gradle plugin 6
   def major = agpVersion[0].toInteger()
   def minor = agpVersion[1].toInteger()

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -31,6 +31,16 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
+
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  // Check AGP version for backward compatibility w/react-native versions still on gradle plugin 6
+  if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+    namespace "com.reactnativecommunity.slider"
+    buildFeatures {
+      buildConfig true
+    }
+  }
+
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
 

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -34,7 +34,9 @@ android {
 
   def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
   // Check AGP version for backward compatibility w/react-native versions still on gradle plugin 6
-  if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+  def major = parsed[0].toInteger()
+  def minor = parsed[1].toInteger()
+  if ((major == 7 && minor >= 3) || major >= 8) {
     namespace "com.reactnativecommunity.slider"
     buildFeatures {
       buildConfig true


### PR DESCRIPTION
Summary:
---------

This is the minimum required change for this module to work on react-native 0.73 which includes android gradle plugin 8

This module does not just require namespace it also requires the buildConfig feature turned on, as discovered in actual use in a work app as I tested AGP8+ to fix up modules I maintain and modules I depend on

* Supercedes #519

It is similar to changes I needed to do as react-native-firebase maintainer --> https://github.com/invertase/react-native-firebase/commit/b52d0ce6723c077190618641ce0f33ced9fd4090

## Test Plan

With apologies, you have to alter an app that integrates this module to use android gradle plugin 8, it's difficult to do that in repos I'm proposing these changes in because bumping to android gradle plugin 8 requries a large amount of transitive dependency changes in CI

I have integrated this in an app and tested it, and done similar work as maintainer of react-native-firebase, react-native-netinfo and react-native-device-info, and I'm now pushing these out to the repos

Cheers