### PR TITLE
feat: [IOS] - thumbSize props 

### DIFF
--- a/package/ios/RNCSlider.h
+++ b/package/ios/RNCSlider.h
@@ -26,6 +26,7 @@
 @property (nonatomic, strong) UIImage *minimumTrackImage;
 @property (nonatomic, strong) UIImage *maximumTrackImage;
 @property (nonatomic, strong) UIImage *thumbImage;
+@property (nonatomic, assign) CGSize thumbSize;
 @property (nonatomic, assign) bool tapToSeek;
 @property (nonatomic, strong) NSString *accessibilityUnits;
 @property (nonatomic, strong) NSArray *accessibilityIncrements;

--- a/package/ios/RNCSlider.m
+++ b/package/ios/RNCSlider.m
@@ -113,9 +113,11 @@
   return [self thumbImageForState:UIControlStateNormal];
 }
 
-- (void)setThumbImage:(UIImage *)thumbImage
-{
-  [self setThumbImage:thumbImage forState:UIControlStateNormal];
+- (void)setThumbImage:(UIImage *)thumbImage {
+    if (!CGSizeEqualToSize(self.thumbSize, CGSizeZero)) {
+        thumbImage = [self resizeImage:thumbImage toSize:self.thumbSize];
+    }
+    [super setThumbImage:thumbImage forState:UIControlStateNormal];
 }
 
 - (UIImage *)thumbImage
@@ -130,6 +132,14 @@
   } else {
     self.transform = CGAffineTransformMakeScale(1, 1);
   }
+}
+
+- (UIImage *)resizeImage:(UIImage *)image toSize:(CGSize)newSize {
+    UIGraphicsBeginImageContextWithOptions(newSize, NO, 0.0);
+    [image drawInRect:CGRectMake(0, 0, newSize.width, newSize.height)];
+    UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return newImage;
 }
 
 - (void)setDisabled:(BOOL)disabled

--- a/package/ios/RNCSliderComponentView.h
+++ b/package/ios/RNCSliderComponentView.h
@@ -26,6 +26,7 @@ typedef void (^RNCLoadImageFailureBlock)();
 @property (nonatomic, strong) UIImage *minimumTrackImage;
 @property (nonatomic, strong) UIImage *maximumTrackImage;
 @property (nonatomic, strong) UIImage *thumbImage;
+@property (nonatomic, assign) CGSize thumbSize;
 @property (nonatomic, assign) bool tapToSeek;
 @property (nonatomic, strong) NSString *accessibilityUnits;
 @property (nonatomic, strong) NSArray *accessibilityIncrements;

--- a/package/ios/RNCSliderComponentView.mm
+++ b/package/ios/RNCSliderComponentView.mm
@@ -159,6 +159,19 @@ using namespace facebook::react;
     const auto &oldScreenProps = *std::static_pointer_cast<const RNCSliderProps>(_props);
     const auto &newScreenProps = *std::static_pointer_cast<const RNCSliderProps>(props);
     
+    if (oldScreenProps.thumbSize != newScreenProps.thumbSize) {
+        slider.thumbSize = CGSizeMake(newScreenProps.thumbSize.width, newScreenProps.thumbSize.height);
+    }
+    if (oldScreenProps.thumbImage != newScreenProps.thumbImage || oldScreenProps.thumbSize != newScreenProps.thumbSize) {
+        [self loadImageFromImageSource:newScreenProps.thumbImage completionBlock:^(NSError *error, UIImage *image) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self->slider setThumbImage:image withSize:self->slider.thumbSize];
+            });
+        }
+        failureBlock:^{
+            [self->slider setThumbImage:nil];
+        }];
+    }   
     if (oldScreenProps.value != newScreenProps.value) {
         if (!slider.isSliding) {
             slider.value = newScreenProps.value;

--- a/package/ios/RNCSliderManager.m
+++ b/package/ios/RNCSliderManager.m
@@ -167,6 +167,7 @@ RCT_EXPORT_VIEW_PROPERTY(onRNCSliderSlidingStart, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onRNCSliderSlidingComplete, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(thumbTintColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(thumbImage, UIImage);
+RCT_EXPORT_VIEW_PROPERTY(thumbSize, CGSize);
 RCT_EXPORT_VIEW_PROPERTY(inverted, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(tapToSeek, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(accessibilityUnits, NSString);

--- a/package/src/RNCSliderNativeComponent.ts
+++ b/package/src/RNCSliderNativeComponent.ts
@@ -3,10 +3,10 @@ import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNati
 //@ts-ignore
 import type {ImageSource} from 'react-native/Libraries/Image/ImageSource';
 import type {
+  BubblingEventHandler,
+  DirectEventHandler,
   Float,
   WithDefault,
-  DirectEventHandler,
-  BubblingEventHandler,
 } from 'react-native/Libraries/Types/CodegenTypes';
 
 type Event = Readonly<{
@@ -34,6 +34,7 @@ export interface NativeProps extends ViewProps {
   step?: Float;
   testID?: string;
   thumbImage?: ImageSource;
+  thumbSize?: {width: number; height: number};
   thumbTintColor?: ColorValue;
   trackImage?: ImageSource;
   value?: Float;

--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import {
-  Image,
-  Platform,
-  StyleSheet,
   AccessibilityActionEvent,
+  ColorValue,
+  Image,
+  NativeSyntheticEvent,
+  Platform,
+  StyleProp,
+  StyleSheet,
   ViewProps,
   ViewStyle,
-  ColorValue,
-  NativeSyntheticEvent,
-  StyleProp,
 } from 'react-native';
 import RCTSliderNativeComponent from './index';
 //@ts-ignore
@@ -164,6 +164,7 @@ type Props = ViewProps &
      * Sets an image for the thumb. Only static images are supported.
      */
     thumbImage?: ImageSource;
+    thumbSize?: {width: number; height: number};
 
     /**
      * If true the slider will be inverted.
@@ -261,6 +262,7 @@ const SliderComponent = (
           ? Image.resolveAssetSource(props.thumbImage)
           : undefined
       }
+      thumbSize={props.thumbSize}
       ref={forwardedRef}
       style={style}
       onChange={onValueChangeEvent}

--- a/package/typings/index.d.ts
+++ b/package/typings/index.d.ts
@@ -41,6 +41,7 @@ export interface SliderPropsIOS extends ReactNative.ViewProps {
    * Sets an image for the thumb. Only static images are supported.
    */
   thumbImage?: ReactNative.ImageURISource;
+  thumbSize?: {width: number; height: number};
 
   /**
    * Assigns a single image for the track. Only static images


### PR DESCRIPTION
Summary:
---------

This slider lacks the ability to change the thumb size on iOS. Since I don't want to use the image as a thumb, I would like to be able to resize it. I'm not a specialist in objective-c, but I have a problem with passing thumbSize and controlling the thumb size. Could someone help me create such a feature? 