### PR TITLE
[iOS] Use install_module_dependencies in podspec file

### DIFF
--- a/package/react-native-slider.podspec
+++ b/package/react-native-slider.podspec
@@ -16,23 +16,26 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/callstack/react-native-slider.git", :tag => "v#{s.version}" }
   s.source_files = "ios/**/*.{h,m,mm}"
+  if defined?(install_modules_dependencies)
+    install_modules_dependencies(s)
+  else
+    s.dependency 'React-Core'
 
-  s.dependency 'React-Core'
+    # This guard prevent to install the dependencies when we run `pod install` in the old architecture.
+    if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
+      s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
+      s.pod_target_xcconfig    = {
+          "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+          "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
+      }
 
-  # This guard prevent to install the dependencies when we run `pod install` in the old architecture.
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-        "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
-
-    s.dependency "React-RCTFabric"
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
+      s.dependency "React-RCTFabric"
+      s.dependency "React-Codegen"
+      s.dependency "RCT-Folly"
+      s.dependency "RCTRequired"
+      s.dependency "RCTTypeSafety"
+      s.dependency "ReactCommon/turbomodule/core"
+    end
   end
 end


### PR DESCRIPTION
# Summary

In RN 0.70, the core team introduced the `install_modules_dependencies` function to properly configure the iOS dependencies in the podspec.
This allow the Core team to add/remove flags and restructure the internal Cocoapods' structure of React Native and limiting the chances to break 3rd parties dependencies, as those changes will be captured by the function.

By not using this function, all the 3rd party libraries would have to chase and manually reimplement the same changes that the RN Core team applies to the Cocoapods structure. 

## Test Plan

```
npx react-native@next init NewApp --version next --skip-install
cd NewApp
yarn add @react-native-community/slider   
yarn install
cd ios
bundle install
RCT_NEW_ARCH_ENABLED=1 bundle exec pod install
open NewApp.xcworkspace
```

Build and observe the failure.

<img width="752" alt="Screenshot 2023-11-30 at 10 23 10" src="https://github.com/callstack/react-native-slider/assets/11162307/17c96d8e-1706-4b3a-bc9b-2d3180dcb234">

Apply this patch to the `NewApp/node_modules/react-native-pager-view/react-native-pager-view.podspec` file and rerun

```
RCT_NEW_ARCH_ENABLED=1 bundle exec pod install
open NewApp.xcworkspace
```
Build and observe the app build successfully:

<img width="1075" alt="Screenshot 2023-11-30 at 10 26 21" src="https://github.com/callstack/react-native-slider/assets/11162307/a8420794-4228-4ae7-96ea-fb2c54429ffd">

### What's required for testing (prerequisites)?
Nothing

### What are the steps to reproduce (after prerequisites)?
See test plan

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅       |
| Android |    N/A      |

## Checklist

The below items are not needed:
- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
