### PR TITLE
feat: add visionos support

### DIFF
--- a/package/react-native-slider.podspec
+++ b/package/react-native-slider.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platform     = :ios, "9.0"
+  s.platforms    = { :ios => "9.0", :visionos => "1.0" }
 
   s.source       = { :git => "https://github.com/callstack/react-native-slider.git", :tag => "v#{s.version}" }
   s.source_files = "ios/**/*.{h,m,mm}"


### PR DESCRIPTION
Summary:
---------

This PR adds visionOS support.


https://github.com/callstack/react-native-slider/assets/52801365/2d9460f4-2b53-47d4-9e1a-74e55b3ebc17

Test Plan:
----------

1. Init the `visionos` app with: `npx @callstack/react-native-visionos init MyApp`
2. Add slider
3. Test if it works