### PR TITLE
Web-Specific Fixes for onValueChange and Deprecated React Methods

### DIFF
--- a/package/src/RNCSliderNativeComponent.web.tsx
+++ b/package/src/RNCSliderNativeComponent.web.tsx
@@ -211,7 +211,7 @@ const RCTSliderWebComponent = React.forwardRef(
         alignItems: 'center',
       },
       style,
-    ];
+    ] as ViewStyle[];
 
     const trackStyle = {
       height: trackHeight,
@@ -241,7 +241,7 @@ const RCTSliderWebComponent = React.forwardRef(
         overflow: 'hidden',
       },
       thumbStyle,
-    ];
+    ] as ViewStyle[];
 
     const decimalPrecision = React.useRef(
       calculatePrecision(minimumValue, maximumValue, step),
@@ -344,8 +344,7 @@ const RCTSliderWebComponent = React.forwardRef(
         onMoveShouldSetResponder={() => !disabled}
         onResponderGrant={() => onSlidingStart(value)}
         onResponderRelease={onTouchEnd}
-        onResponderMove={onMove}
-      >
+        onResponderMove={onMove}>
         <Animated.View pointerEvents="none" style={minimumTrackStyle} />
         <View pointerEvents="none" style={thumbViewStyle}>
           {thumbImage !== undefined ? (

--- a/package/src/RNCSliderNativeComponent.web.tsx
+++ b/package/src/RNCSliderNativeComponent.web.tsx
@@ -4,7 +4,6 @@ import React, {RefObject, useCallback} from 'react';
 import {
   Animated,
   View,
-  StyleSheet,
   ColorValue,
   ViewStyle,
   GestureResponderEvent,
@@ -118,6 +117,7 @@ const RCTSliderWebComponent = React.forwardRef(
 
     const onSlidingStart = useCallback(
       (value: number) => {
+        isUserInteracting.current = true;
         onRNCSliderSlidingStart && onRNCSliderSlidingStart(valueToEvent(value));
       },
       [onRNCSliderSlidingStart],
@@ -125,11 +125,14 @@ const RCTSliderWebComponent = React.forwardRef(
 
     const onSlidingComplete = useCallback(
       (value: number) => {
+        isUserInteracting.current = false;
         onRNCSliderSlidingComplete &&
           onRNCSliderSlidingComplete(valueToEvent(value));
       },
       [onRNCSliderSlidingComplete],
     );
+    // Add a ref to track user interaction
+    const isUserInteracting = React.useRef(false);
     const updateValue = useCallback(
       (newValue: number) => {
         // Ensure that the value is correctly rounded
@@ -145,7 +148,9 @@ const RCTSliderWebComponent = React.forwardRef(
         );
         if (value !== withinBounds) {
           setValue(withinBounds);
-          onValueChange(withinBounds);
+          if (isUserInteracting.current) {
+            onValueChange(withinBounds);
+          }
           return withinBounds;
         }
         return hardRounded;
@@ -197,7 +202,7 @@ const RCTSliderWebComponent = React.forwardRef(
       };
     }, [containerRef]);
 
-    const containerStyle = StyleSheet.compose(
+    const containerStyle = [
       {
         flexGrow: 1,
         flexShrink: 1,
@@ -206,7 +211,7 @@ const RCTSliderWebComponent = React.forwardRef(
         alignItems: 'center',
       },
       style,
-    );
+    ];
 
     const trackStyle = {
       height: trackHeight,
@@ -226,7 +231,7 @@ const RCTSliderWebComponent = React.forwardRef(
       flexGrow: maxPercent,
     };
 
-    const thumbViewStyle = StyleSheet.compose(
+    const thumbViewStyle = [
       {
         width: thumbSize,
         height: thumbSize,
@@ -236,7 +241,7 @@ const RCTSliderWebComponent = React.forwardRef(
         overflow: 'hidden',
       },
       thumbStyle,
-    );
+    ];
 
     const decimalPrecision = React.useRef(
       calculatePrecision(minimumValue, maximumValue, step),
@@ -339,7 +344,8 @@ const RCTSliderWebComponent = React.forwardRef(
         onMoveShouldSetResponder={() => !disabled}
         onResponderGrant={() => onSlidingStart(value)}
         onResponderRelease={onTouchEnd}
-        onResponderMove={onMove}>
+        onResponderMove={onMove}
+      >
         <Animated.View pointerEvents="none" style={minimumTrackStyle} />
         <View pointerEvents="none" style={thumbViewStyle}>
           {thumbImage !== undefined ? (

--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -192,7 +192,7 @@ const SliderComponent = (
   props: Props,
   forwardedRef?: Ref<typeof RCTSliderNativeComponent>,
 ) => {
-  const style = [props.style, styles.slider];
+  const style = props.style ? [props.style, styles.slider] : styles.slider;
 
   const {
     onValueChange,

--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -192,7 +192,7 @@ const SliderComponent = (
   props: Props,
   forwardedRef?: Ref<typeof RCTSliderNativeComponent>,
 ) => {
-  const style = StyleSheet.compose(props.style, styles.slider);
+  const style = [props.style, styles.slider];
 
   const {
     onValueChange,


### PR DESCRIPTION
### Web-Specific Fixes for onValueChange and Deprecated React Methods

**Changes:**
1. **Web-Specific onValueChange**: Adjusted `onValueChange` in `RNCSliderNativeComponent.web.tsx` to trigger only during user interactions, addressing platform-specific inconsistencies (issue #562).
2. **Deprecated React Methods**: Updated `Slider.tsx` and `RNCSliderNativeComponent.web.tsx`, replacing deprecated `StyleSheet.compose` with array syntax.

These updates fixes an inconsistency in the web platform and improves compatibility with newer React versions.

Related Issue: #562