### PR TITLE
feat: add slider limits to web

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ To use this library you need to ensure you are using the correct version of Reac
 | `maximumValue` | Initial maximum value of the slider.<br/>Default value is 1. | number | No | |
 | `minimumTrackTintColor` | The color used for the track to the left of the button.<br/>Overrides the default blue gradient image on iOS. | [color](https://reactnative.dev/docs/colors) | No | |
 | `minimumValue` | Initial minimum value of the slider.<br/>Default value is 0. | number | No | |
-| `lowerLimit` | Slide lower limit. The user won't be able to slide below this limit. | number | No | Android, iOS |
-| `upperLimit` | Slide upper limit. The user won't be able to slide above this limit. | number | No | Android, iOS |
+| `lowerLimit` | Slide lower limit. The user won't be able to slide below this limit. | number | No | Android, iOS, Web |
+| `upperLimit` | Slide upper limit. The user won't be able to slide above this limit. | number | No | Android, iOS, Web |
 | `onSlidingStart` | Callback that is called when the user picks up the slider.<br/>The initial value is passed as an argument to the callback handler. | function | No | |
 | `onSlidingComplete` | Callback that is called when the user releases the slider, regardless if the value has changed.<br/>The current value is passed as an argument to the callback handler. | function | No | |
 | `onValueChange` | Callback continuously called while the user is dragging the slider. | function | No | |
@@ -129,7 +129,7 @@ npm run test
 
 When [creating an issue](https://github.com/callstack/react-native-slider/issues/new/choose) please remember to specify the platform which the issue occurs on.
 
-## Running the example app 
+## Running the example app
 While developing, you can run the example app to test your changes.
 
 ### Setup
@@ -145,12 +145,12 @@ You can also do this manually by:
 
 ### New architecture setup (Fabric)
 
-In order to use the new architecture some extra steps are needed. 
-#### iOS 
+In order to use the new architecture some extra steps are needed.
+#### iOS
 - Install pods with new arch flag inside `example/ios` folder: `RCT_NEW_ARCH_ENABLED=1 pod install`
 - Run `npm run example-ios`
 
-#### Android 
+#### Android
 - Set `newArchEnabled` to true inside `example/android/gradle.properties`
 - Run `npm run example-android`
 
@@ -159,7 +159,7 @@ In order to use the new architecture some extra steps are needed.
 If you are using React Native version lower than 0.70, you need to setup manual linking for Android to work.
 </summary>
 
-Inside `example/android/app/src/main/jni/Android.mk` add these lines: 
+Inside `example/android/app/src/main/jni/Android.mk` add these lines:
 
 ```diff
 + include $(NODE_MODULES_DIR)/@react-native-community/slider/android/build/generated/source/codegen/jni/Android.mk
@@ -172,7 +172,7 @@ include $(CLEAR_VARS)
     libreact_debug \
 ```
 
-Inside `example/android/app/src/main/jni/MainComponentsRegistry.cpp` update these lines: 
+Inside `example/android/app/src/main/jni/MainComponentsRegistry.cpp` update these lines:
 
 ```diff
 #include <react/renderer/components/rncore/ComponentDescriptors.h>

--- a/example-web/src/Examples.tsx
+++ b/example-web/src/Examples.tsx
@@ -100,6 +100,12 @@ export const examples: Props[] = [
     },
   },
   {
+    title: 'lowerLimit: 2, upperLimit: 7',
+    render(): React.ReactElement {
+      return <SliderExample minimumValue={0} maximumValue={10}  lowerLimit={2} upperLimit={7} />;
+    },
+  },
+  {
     title: 'step: 0.25, tap to seek on iOS',
     render(): React.ReactElement {
       return <SliderExample step={0.25} tapToSeek={true} />;

--- a/package/src/RNCSliderNativeComponent.web.tsx
+++ b/package/src/RNCSliderNativeComponent.web.tsx
@@ -31,8 +31,8 @@ export interface Props {
   value: number;
   minimumValue: number;
   maximumValue: number;
-  lowerLimit: number;
-  upperLimit: number;
+  lowerLimit?: number;
+  upperLimit?: number;
   step: number;
   minimumTrackTintColor: ColorValue;
   maximumTrackTintColor: ColorValue;
@@ -279,10 +279,17 @@ const RCTSliderWebComponent = React.forwardRef(
       } else {
         const x = pageX - containerX;
         const newValue = inverted
-          ? upperValue - ((upperValue - lowerValue) * x) / width
-          : lowerValue + ((upperValue - lowerValue) * x) / width;
+          ? maximumValue - ((maximumValue - minimumValue) * x) / width
+          : minimumValue + ((maximumValue - minimumValue) * x) / width;
 
-        return step ? Math.round(newValue / step) * step : newValue;
+        const valueAfterStep = step
+          ? Math.round(newValue / step) * step
+          : newValue;
+        const valueAfterLowerLimit =
+          valueAfterStep < lowerLimit ? lowerLimit : valueAfterStep;
+        const valueAfterUpperLimit =
+          valueAfterLowerLimit > upperLimit ? upperLimit : valueAfterLowerLimit;
+        return valueAfterUpperLimit;
       }
     };
 
@@ -324,10 +331,8 @@ const RCTSliderWebComponent = React.forwardRef(
       <View
         ref={containerRef}
         onLayout={({nativeEvent: {layout}}: LayoutChangeEvent) => {
-          const lowerValue = lowerLimit === minimumValue ? 0 : lowerLimit;
-          const multiplier = (upperLimit - lowerValue) / maximumValue;
           containerSize.current.height = layout.height;
-          containerSize.current.width = layout.width * multiplier;
+          containerSize.current.width = layout.width;
           if ((containerRef as RefObject<View>).current) {
             updateContainerPositionX();
           }

--- a/package/src/RNCSliderNativeComponent.web.tsx
+++ b/package/src/RNCSliderNativeComponent.web.tsx
@@ -287,9 +287,9 @@ const RCTSliderWebComponent = React.forwardRef(
           : newValue;
         const valueAfterLowerLimit =
           valueAfterStep < lowerLimit ? lowerLimit : valueAfterStep;
-        const valueAfterUpperLimit =
+        const valueInLimitRange =
           valueAfterLowerLimit > upperLimit ? upperLimit : valueAfterLowerLimit;
-        return valueAfterUpperLimit;
+        return valueInLimitRange;
       }
     };
 

--- a/package/src/RNCSliderNativeComponent.web.tsx
+++ b/package/src/RNCSliderNativeComponent.web.tsx
@@ -31,6 +31,8 @@ export interface Props {
   value: number;
   minimumValue: number;
   maximumValue: number;
+  lowerLimit: number;
+  upperLimit: number;
   step: number;
   minimumTrackTintColor: ColorValue;
   maximumTrackTintColor: ColorValue;
@@ -55,6 +57,8 @@ const RCTSliderWebComponent = React.forwardRef(
       value: initialValue,
       minimumValue = 0,
       maximumValue = 0,
+      lowerLimit = 0,
+      upperLimit = 0,
       step = 1,
       minimumTrackTintColor = '#009688',
       maximumTrackTintColor = '#939393',
@@ -265,16 +269,18 @@ const RCTSliderWebComponent = React.forwardRef(
         updateContainerPositionX();
       }
       const containerX = containerPositionX.current;
+      const lowerValue = minimumValue < lowerLimit ? lowerLimit : minimumValue;
+      const upperValue = maximumValue > upperLimit ? upperLimit : maximumValue;
 
       if (pageX < containerX) {
-        return inverted ? maximumValue : minimumValue;
+        return inverted ? upperValue : lowerValue;
       } else if (pageX > containerX + width) {
-        return inverted ? minimumValue : maximumValue;
+        return inverted ? lowerValue : upperValue;
       } else {
         const x = pageX - containerX;
         const newValue = inverted
-          ? maximumValue - ((maximumValue - minimumValue) * x) / width
-          : minimumValue + ((maximumValue - minimumValue) * x) / width;
+          ? upperValue - ((upperValue - lowerValue) * x) / width
+          : lowerValue + ((upperValue - lowerValue) * x) / width;
 
         return step ? Math.round(newValue / step) * step : newValue;
       }
@@ -318,8 +324,10 @@ const RCTSliderWebComponent = React.forwardRef(
       <View
         ref={containerRef}
         onLayout={({nativeEvent: {layout}}: LayoutChangeEvent) => {
+          const lowerValue = lowerLimit === minimumValue ? 0 : lowerLimit;
+          const multiplier = (upperLimit - lowerValue) / maximumValue;
           containerSize.current.height = layout.height;
-          containerSize.current.width = layout.width;
+          containerSize.current.width = layout.width * multiplier;
           if ((containerRef as RefObject<View>).current) {
             updateContainerPositionX();
           }

--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -251,7 +251,7 @@ const SliderComponent = (
       : Platform.select({
           web: localProps.maximumValue,
           default: LIMIT_MAX_VALUE,
-      });
+        });
 
   return (
     <RCTSliderNativeComponent

--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -248,7 +248,10 @@ const SliderComponent = (
   const upperLimit =
     !!localProps.upperLimit || localProps.upperLimit === 0
       ? localProps.upperLimit
-      : Platform.select({ web: localProps.maximumValue, default: LIMIT_MAX_VALUE });
+      : Platform.select({
+          web: localProps.maximumValue,
+          default: LIMIT_MAX_VALUE,
+      });
 
   return (
     <RCTSliderNativeComponent

--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -240,12 +240,12 @@ const SliderComponent = (
   const lowerLimit =
     !!localProps.lowerLimit || localProps.lowerLimit === 0
       ? localProps.lowerLimit
-      : LIMIT_MIN_VALUE;
+      : Platform.select({ web: localProps.minimumValue, default: LIMIT_MIN_VALUE });
 
   const upperLimit =
     !!localProps.upperLimit || localProps.upperLimit === 0
       ? localProps.upperLimit
-      : LIMIT_MAX_VALUE;
+      : Platform.select({ web: localProps.maximumValue, default: LIMIT_MAX_VALUE });
 
   return (
     <RCTSliderNativeComponent
@@ -284,8 +284,8 @@ SliderWithRef.defaultProps = {
   step: 0,
   inverted: false,
   tapToSeek: false,
-  lowerLimit: LIMIT_MIN_VALUE,
-  upperLimit: LIMIT_MAX_VALUE,
+  lowerLimit: Platform.select({ web: undefined, default: LIMIT_MIN_VALUE }),
+  upperLimit: Platform.select({ web: undefined, default: LIMIT_MAX_VALUE }),
 };
 
 let styles = StyleSheet.create(

--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -290,8 +290,8 @@ SliderWithRef.defaultProps = {
   step: 0,
   inverted: false,
   tapToSeek: false,
-  lowerLimit: Platform.select({ web: undefined, default: LIMIT_MIN_VALUE }),
-  upperLimit: Platform.select({ web: undefined, default: LIMIT_MAX_VALUE }),
+  lowerLimit: Platform.select({web: undefined, default: LIMIT_MIN_VALUE}),
+  upperLimit: Platform.select({web: undefined, default: LIMIT_MAX_VALUE}),
 };
 
 let styles = StyleSheet.create(

--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -240,7 +240,10 @@ const SliderComponent = (
   const lowerLimit =
     !!localProps.lowerLimit || localProps.lowerLimit === 0
       ? localProps.lowerLimit
-      : Platform.select({ web: localProps.minimumValue, default: LIMIT_MIN_VALUE });
+      : Platform.select({
+          web: localProps.minimumValue,
+          default: LIMIT_MIN_VALUE,
+        });
 
   const upperLimit =
     !!localProps.upperLimit || localProps.upperLimit === 0


### PR DESCRIPTION
Continues on abandoned PR: https://github.com/callstack/react-native-slider/pull/520

Summary:
---------

Add upperLimit support and lowerLimit support to web.


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Also added an example to the web-example project.
https://github.com/callstack/react-native-slider/assets/38087818/32c09f40-cbc4-4dec-ba51-0cda036ef442

