### PR TITLE
fix keyboard progress increment getting stuck at 6

### DIFF
--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -216,6 +216,11 @@ public class ReactSlider extends AppCompatSeekBar {
       mStepCalculated = (mMaxValue - mMinValue) / (double) DEFAULT_TOTAL_STEPS;
     }
     setMax(getTotalSteps());
+
+    // setMax updates the internal "mKeyProgressIncrement" and on initial load the value will be set to
+    // 6 due to Math.round(DEFAULT_TOTAL_STEPS (128) / 20). And its hard to get it out of 6 if the range
+    // is not high enough so lets revert it back to 1 to respect mStep
+    setKeyProgressIncrement(1);
     updateLowerLimit();
     updateUpperLimit();
     updateValue();


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

This fixes https://github.com/callstack/react-native-slider/issues/155

see https://github.com/callstack/react-native-slider/issues/155#issuecomment-1918183040 for details of the issue

The gist of it, on initial load `ReactSlider` calls

`setMax(128)`

which calls the `AbsSeekBar.java`'s `setMax()`

https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/widget/AbsSeekBar.java;l=586-595;drc=c8c729556d69aa27fff24e5412140563fc1527af

and internally updates `keyProgressIncrement` to `6`

that causes keyboard input to jump 6 steps:

https://android.googlesource.com/platform/frameworks/base/+/711efaa0297f845c60a1de0acce680493f90bf02/core/java/android/widget/AbsSeekBar.java#1053

after setting  `ReactSlider.setMaxValue`, if `max` is not high enough, the  `keyProgressIncrement`  will still get stuck at `6`

due to this logic in `AbsSeekBar`:


https://android.googlesource.com/platform/frameworks/base/+/711efaa0297f845c60a1de0acce680493f90bf02/core/java/android/widget/AbsSeekBar.java#590

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->