### PR TITLE
chore: update actions to latest versions

### DIFF
--- a/.github/workflows/ReactNativeSlider-CI.yml
+++ b/.github/workflows/ReactNativeSlider-CI.yml
@@ -15,11 +15,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache node modules
         id: cache-package-npm
-        uses: actions/cache@v3.0.7
+        uses: actions/cache@v4
         env:
           cache-name: cached-ci-npm-deps
         with:
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Pull npm dependencies
-        uses: actions/cache@v3.0.7
+        uses: actions/cache@v4
         with:
           path: ./package/node_modules
           key: ${{ hashFiles('./package/package.json') }}
@@ -60,10 +60,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Pull npm dependencies
-        uses: actions/cache@v3.0.7
+        uses: actions/cache@v4
         with:
           path: ./package/node_modules
           key: ${{ hashFiles('./package/package.json') }}
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: npm install
@@ -95,12 +95,12 @@ jobs:
     needs: [verify-example-sources]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Pull the npm dependencies
         run: npm install
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '11'
@@ -114,11 +114,11 @@ jobs:
     runs-on: macos-latest
     needs: [verify-example-sources]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cached-ios-npm-deps
         with:
@@ -132,7 +132,7 @@ jobs:
 
       - name: Cache Pods
         id: cache-pods
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cached-ios-pods-deps
         with:
@@ -166,11 +166,11 @@ jobs:
     runs-on: macos-latest
     needs: [build-iOS-app]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cached-ios-npm-deps
         with:
@@ -184,7 +184,7 @@ jobs:
 
       - name: Cache Pods
         id: cache-pods
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cached-ios-pods-deps
         with:
@@ -222,7 +222,7 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
Summary:
---------

- Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-java@v3, actions/cache@v3.0.7.
- For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.