### PR TITLE
fix: new arch measurements on Android

### DIFF
--- a/.github/workflows/ReactNativeSlider-CI.yml
+++ b/.github/workflows/ReactNativeSlider-CI.yml
@@ -157,7 +157,7 @@ jobs:
           device=$(xcrun simctl list devices "${device_name}" available | grep "${device_name} (")
           re='\(([-0-9A-Fa-f]+)\)'
           [[ $device =~ $re ]] || exit 1
-          xcodebuild -workspace example.xcworkspace -scheme example -destination "platform=iOS Simulator,id=${BASH_REMATCH[1]}" CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build
+          set -o pipefail && xcodebuild -workspace example.xcworkspace -scheme example -destination "platform=iOS Simulator,id=${BASH_REMATCH[1]}" CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build | xcbeautify --renderer github-actions
         working-directory: example/ios
 
 
@@ -209,7 +209,7 @@ jobs:
           device=$(xcrun simctl list devices "${device_name}" available | grep "${device_name} (")
           re='\(([-0-9A-Fa-f]+)\)'
           [[ $device =~ $re ]] || exit 1
-          xcodebuild -workspace example.xcworkspace -scheme example -destination "platform=iOS Simulator,id=${BASH_REMATCH[1]}" CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build
+          set -o pipefail && xcodebuild -workspace example.xcworkspace -scheme example -destination "platform=iOS Simulator,id=${BASH_REMATCH[1]}" CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build | xcbeautify --renderer github-actions
         working-directory: example/ios
 
 

--- a/.github/workflows/ReactNativeSlider-CI.yml
+++ b/.github/workflows/ReactNativeSlider-CI.yml
@@ -191,6 +191,9 @@ jobs:
           path: example/ios/Pods
           key: new-arch-${{ hashFiles('./example/ios/Podfile.lock') }}
 
+      - name: Use the current package sources in build
+        run: cd example && npm run refresh-package
+
       - name: Install required dependencies on cache miss (Pods)
         if: steps.cache-pods.outputs.cache-hit != 'true'
         run: |
@@ -199,9 +202,6 @@ jobs:
       - name: Reinstall Pods only if using cached ones
         if: steps.cache-pods.outputs.cache-hit == 'true'
         run: cd example/ios && RCT_NEW_ARCH_ENABLED=1 pod install
-
-      - name: Use the current package sources in build
-        run: cd example && npm run refresh-package
 
       - name: Build iOS - Fabric
         run: |

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -3,13 +3,6 @@ PODS:
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.73.5)
-  - FBReactNativeSpec (0.73.5):
-    - RCT-Folly (= 2022.05.16.00)
-    - RCTRequired (= 0.73.5)
-    - RCTTypeSafety (= 0.73.5)
-    - React-Core (= 0.73.5)
-    - React-jsi (= 0.73.5)
-    - ReactCommon/turbomodule/core (= 0.73.5)
   - Flipper (0.201.0):
     - Flipper-Folly (~> 2.6)
   - Flipper-Boost-iOSX (1.76.0.1.11)
@@ -116,17 +109,21 @@ PODS:
   - React-callinvoker (0.73.5)
   - React-Codegen (0.73.5):
     - DoubleConversion
-    - FBReactNativeSpec
     - glog
     - hermes-engine
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-FabricImage
+    - React-graphics
     - React-jsi
     - React-jsiexecutor
     - React-NativeModulesApple
-    - React-rncore
+    - React-rendererdebug
+    - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
   - React-Core (0.73.5):
@@ -939,19 +936,71 @@ PODS:
     - React-jsi (= 0.73.5)
     - React-perflogger (= 0.73.5)
   - React-jsinspector (0.73.5)
+  - React-jsitracing (0.73.5):
+    - React-jsi
   - React-logger (0.73.5):
     - glog
   - React-Mapbuffer (0.73.5):
     - glog
     - React-debug
-  - react-native-pager-view (6.2.3):
+  - react-native-pager-view (6.3.0):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - react-native-slider (4.5.0):
     - glog
+    - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-graphics
+    - React-ImageManager
+    - react-native-slider/common (= 4.5.0)
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - react-native-slider/common (4.5.0):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2022.05.16.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - React-nativeconfig (0.73.5)
   - React-NativeModulesApple (0.73.5):
     - glog
@@ -980,13 +1029,21 @@ PODS:
     - RCTTypeSafety
     - React-Core
     - React-CoreModules
+    - React-debug
+    - React-Fabric
+    - React-graphics
     - React-hermes
     - React-nativeconfig
     - React-NativeModulesApple
     - React-RCTFabric
     - React-RCTImage
     - React-RCTNetwork
+    - React-rendererdebug
+    - React-RuntimeApple
+    - React-RuntimeCore
+    - React-RuntimeHermes
     - React-runtimescheduler
+    - React-utils
     - ReactCommon
   - React-RCTBlob (0.73.5):
     - hermes-engine
@@ -1064,8 +1121,42 @@ PODS:
     - RCT-Folly (= 2022.05.16.00)
     - React-debug
   - React-rncore (0.73.5)
+  - React-RuntimeApple (0.73.5):
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - React-callinvoker
+    - React-Core/Default
+    - React-CoreModules
+    - React-cxxreact
+    - React-jserrorhandler
+    - React-jsi
+    - React-jsiexecutor
+    - React-Mapbuffer
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-RuntimeCore
+    - React-runtimeexecutor
+    - React-RuntimeHermes
+    - React-utils
+  - React-RuntimeCore (0.73.5):
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - React-cxxreact
+    - React-jserrorhandler
+    - React-jsi
+    - React-jsiexecutor
+    - React-runtimeexecutor
+    - React-runtimescheduler
   - React-runtimeexecutor (0.73.5):
     - React-jsi (= 0.73.5)
+  - React-RuntimeHermes (0.73.5):
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - React-jsi
+    - React-jsitracing
+    - React-nativeconfig
+    - React-utils
   - React-runtimescheduler (0.73.5):
     - glog
     - hermes-engine
@@ -1126,7 +1217,6 @@ DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
-  - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
   - Flipper (= 0.201.0)
   - Flipper-Boost-iOSX (= 1.76.0.1.11)
   - Flipper-DoubleConversion (= 3.2.0.1)
@@ -1173,6 +1263,7 @@ DEPENDENCIES:
   - React-jsi (from `../node_modules/react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector-modern`)
+  - React-jsitracing (from `../node_modules/react-native/ReactCommon/hermes/executor/`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - react-native-pager-view (from `../node_modules/react-native-pager-view`)
@@ -1193,7 +1284,10 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - React-rendererdebug (from `../node_modules/react-native/ReactCommon/react/renderer/debug`)
   - React-rncore (from `../node_modules/react-native/ReactCommon`)
+  - React-RuntimeApple (from `../node_modules/react-native/ReactCommon/react/runtime/platform/ios`)
+  - React-RuntimeCore (from `../node_modules/react-native/ReactCommon/react/runtime`)
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
+  - React-RuntimeHermes (from `../node_modules/react-native/ReactCommon/react/runtime`)
   - React-runtimescheduler (from `../node_modules/react-native/ReactCommon/react/renderer/runtimescheduler`)
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
@@ -1222,8 +1316,6 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec"
   FBLazyVector:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
-  FBReactNativeSpec:
-    :path: "../node_modules/react-native/React/FBReactNativeSpec"
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   hermes-engine:
@@ -1267,6 +1359,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsiexecutor"
   React-jsinspector:
     :path: "../node_modules/react-native/ReactCommon/jsinspector-modern"
+  React-jsitracing:
+    :path: "../node_modules/react-native/ReactCommon/hermes/executor/"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
   React-Mapbuffer:
@@ -1307,8 +1401,14 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/react/renderer/debug"
   React-rncore:
     :path: "../node_modules/react-native/ReactCommon"
+  React-RuntimeApple:
+    :path: "../node_modules/react-native/ReactCommon/react/runtime/platform/ios"
+  React-RuntimeCore:
+    :path: "../node_modules/react-native/ReactCommon/react/runtime"
   React-runtimeexecutor:
     :path: "../node_modules/react-native/ReactCommon/runtimeexecutor"
+  React-RuntimeHermes:
+    :path: "../node_modules/react-native/ReactCommon/react/runtime"
   React-runtimescheduler:
     :path: "../node_modules/react-native/ReactCommon/react/renderer/runtimescheduler"
   React-utils:
@@ -1323,7 +1423,6 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: 56e0e498dbb513b96c40bac6284729ba4e62672d
-  FBReactNativeSpec: 146c741a3f40361f6bc13a4ba284678cbedb5881
   Flipper: c7a0093234c4bdd456e363f2f19b2e4b27652d44
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
@@ -1342,7 +1441,7 @@ SPEC CHECKSUMS:
   RCTTypeSafety: 50efabe2b115c11ed03fbf3fd79e2f163ddb5d7c
   React: 84221d5e0ce297bc57c4b6af539a62d812d89f10
   React-callinvoker: 5d17577ecc7f784535ebedf3aad4bcbf8f4b5117
-  React-Codegen: 857e7984fc277aadde2a7a427288b6918ece7b2b
+  React-Codegen: 622eb4971c887cd198ce55346860635430fe8f72
   React-Core: 8e782e7e24c7843871a0d9c3c8d7c5b3ebb73832
   React-CoreModules: 7875ee247e3e6e0e683b52cd1cdda1b71618bd55
   React-cxxreact: 788cd771c6e94d44f8d472fdfae89b67226067ea
@@ -1356,18 +1455,19 @@ SPEC CHECKSUMS:
   React-jsi: 1d59d0a148c76641ac577729e0268bafa494152c
   React-jsiexecutor: 262b66928ad948491d03fd328bb5b822cce94647
   React-jsinspector: 32db5e364bcae8fca8cdf8891830636275add0c5
+  React-jsitracing: 42912570ecc01b07e29894a1a05a54f270e683ce
   React-logger: 0331362115f0f5b392bd7ed14636d1a3ea612479
   React-Mapbuffer: 7c35cd53a22d0be04d3f26f7881c7fb7dd230216
-  react-native-pager-view: d5f3adb58a4e6e0d200055e9a4afdcda9b9022ce
-  react-native-slider: 09e5a8b7e766d3b5ae24ec15c5c4ec2679ca0f8c
+  react-native-pager-view: b5c1234655bc56d201f8ea1ce887f6cabeafd61b
+  react-native-slider: e4be63dee7fb65a2318468de34aa9a423a2112f6
   React-nativeconfig: 1166714a4f7ea57a0df5c2cb44fbc70f98d580f9
   React-NativeModulesApple: 726664e9829eb5eed8170241000e46ead269a05f
   React-perflogger: 0dd9f1725d55f8264b81efadd373fe1d9cca7dc2
   React-RCTActionSheet: 05656d2102b0d0a2676d58bad4d80106af5367b2
   React-RCTAnimation: 6c66beae98730fb7615df28caf651e295f2401e5
-  React-RCTAppDelegate: 891b80c596fffcb3f90431739495d606a9a0d610
+  React-RCTAppDelegate: d78fa6bcb3c823201b77bb86a967a0efd2dd4eed
   React-RCTBlob: 8ecee445ec5fa9ed8a8621a136183c1045165100
-  React-RCTFabric: f291e06bc63fef26cdd105537bae5c6a8d3bdca8
+  React-RCTFabric: 43929bf7439754d75bd9a88f97c990bfb98c90fd
   React-RCTImage: 585b16465146cb839da02f3179ce7cb19d332642
   React-RCTLinking: 09ba11f7df62946e7ddca1b51aa3bf47b230e008
   React-RCTNetwork: e070f8d2fca60f1e9571936ce54d165e77129e76
@@ -1375,14 +1475,17 @@ SPEC CHECKSUMS:
   React-RCTText: f6cc5a3cf0f1a4f3d1256657dca1025e4cfe45e0
   React-RCTVibration: d9948962139f9924ef87f23ab240e045e496213b
   React-rendererdebug: ee05480666415f7a76e6cf0a7a50363423f44809
-  React-rncore: 010565651e9cf2e4fac9517a348446789dd55e01
+  React-rncore: a93b592afe8ff28029a3c4009e52da14a0516c90
+  React-RuntimeApple: 95172dcfb260834a2bf1c8302b27ef0bc276e079
+  React-RuntimeCore: 404f636cf4144ead99c1bf46fad1cbecede27876
   React-runtimeexecutor: 56f562a608056fb0c1711d900a992e26f375d817
+  React-RuntimeHermes: 4a505ba2d60c4c8523d28f1d69dd5d115d81a6d3
   React-runtimescheduler: 814b644a5f456c7df1fba7bcd9914707152527c6
   React-utils: 987a4526a2fc0acdfaf87888adfe0bf9d0452066
   ReactCommon: 2947b0bffd82ea0e58ca7928881152d4c6dae9af
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Yoga: a716eea57d0d3430219c0a5a233e1e93ee931eb7
+  Yoga: 9e6a04eacbd94f97d94577017e9f23b3ab41cf6c
 
 PODFILE CHECKSUM: c25872b6c8e4ec17e5338750fa46de6bf56fcdce
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.14.3

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -55,7 +55,7 @@ android {
   sourceSets {
     main {
       if (isNewArchitectureEnabled()) {
-          java.srcDirs += ['src/newarch']
+          java.srcDirs += ['src/newarch', "${project.buildDir}/generated/source/codegen/java"]
       } else {
           java.srcDirs += ['src/oldarch']
       }
@@ -73,10 +73,3 @@ dependencies {
   api 'com.facebook.react:react-native:+'
 }
 
-if (isNewArchitectureEnabled()) {
-    react {
-        jsRootDir = file("../src")
-        libraryName = "ReactSlider"
-        codegenJavaPackageName = "com.reactnativecommunity.slider"
-    }
-}

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManagerImpl.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManagerImpl.java
@@ -134,8 +134,16 @@ public class ReactSliderManagerImpl {
         view.setAccessibilityIncrements(stringList);
     }
 
-    public static Map getExportedCustomDirectEventTypeConstants() {
-        return MapBuilder.of(ReactSlidingCompleteEvent.EVENT_NAME, MapBuilder.of("registrationName", "onRNCSliderSlidingComplete"),
-                ReactSlidingStartEvent.EVENT_NAME, MapBuilder.of("registrationName", "onRNCSliderSlidingStart"));
+    public static Map<String, Object> getExportedCustomBubblingEventTypeConstants() {
+        return MapBuilder.of(
+                ReactSliderEvent.EVENT_NAME, MapBuilder.of("registrationName", ReactSliderEvent.EVENT_NAME)
+        );
+    }
+
+    public static Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+        return MapBuilder.of(
+                ReactSlidingStartEvent.EVENT_NAME, MapBuilder.of("registrationName", ReactSlidingStartEvent.EVENT_NAME),
+                ReactSlidingCompleteEvent.EVENT_NAME, MapBuilder.of("registrationName", ReactSlidingCompleteEvent.EVENT_NAME)
+        );
     }
 }

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlidingCompleteEvent.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlidingCompleteEvent.java
@@ -17,7 +17,7 @@ import com.facebook.react.uimanager.events.Event;
  */
 public class ReactSlidingCompleteEvent extends Event<ReactSlidingCompleteEvent> {
 
-    public static final String EVENT_NAME = "topSlidingComplete";
+    public static final String EVENT_NAME = "onRNCSliderSlidingComplete";
 
     private final double mValue;
 

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlidingStartEvent.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlidingStartEvent.java
@@ -17,7 +17,7 @@ import com.facebook.react.uimanager.events.Event;
  */
 
 public class ReactSlidingStartEvent extends Event<ReactSlidingStartEvent> {
-    public static final String EVENT_NAME = "topSlidingStart";
+    public static final String EVENT_NAME = "onRNCSliderSlidingStart";
 
     private final double mValue;
 

--- a/package/android/src/main/jni/CMakeLists.txt
+++ b/package/android/src/main/jni/CMakeLists.txt
@@ -1,0 +1,79 @@
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+set(LIB_LITERAL RNCSlider)
+set(LIB_TARGET_NAME react_codegen_${LIB_LITERAL})
+
+set(LIB_ANDROID_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+set(LIB_COMMON_DIR ${LIB_ANDROID_DIR}/../common/cpp)
+set(LIB_ANDROID_GENERATED_JNI_DIR ${LIB_ANDROID_DIR}/build/generated/source/codegen/jni)
+set(LIB_ANDROID_GENERATED_COMPONENTS_DIR ${LIB_ANDROID_GENERATED_JNI_DIR}/react/renderer/components/${LIB_LITERAL})
+
+add_compile_options(
+  -fexceptions
+  -frtti
+  -std=c++20
+  -Wall
+  -Wpedantic
+  -Wno-gnu-zero-variadic-macro-arguments
+)
+
+file(GLOB LIB_CUSTOM_SRCS CONFIGURE_DEPENDS *.cpp ${LIB_COMMON_DIR}/react/renderer/components/${LIB_LITERAL}/*.cpp)
+file(GLOB LIB_CODEGEN_SRCS CONFIGURE_DEPENDS ${LIB_ANDROID_GENERATED_JNI_DIR}/*.cpp ${LIB_ANDROID_GENERATED_COMPONENTS_DIR}/*.cpp)
+
+add_library(
+  ${LIB_TARGET_NAME}
+  SHARED
+  ${LIB_CUSTOM_SRCS}
+  ${LIB_CODEGEN_SRCS}
+)
+
+target_include_directories(
+  ${LIB_TARGET_NAME}
+  PUBLIC
+  .
+  ${LIB_COMMON_DIR}
+  ${LIB_ANDROID_GENERATED_JNI_DIR}
+  ${LIB_ANDROID_GENERATED_COMPONENTS_DIR}
+)
+
+target_link_libraries(
+  ${LIB_TARGET_NAME}
+  fbjni
+  folly_runtime
+  glog
+  jsi
+  react_codegen_rncore
+  react_debug
+  react_render_componentregistry
+  react_render_core
+  react_render_debug
+  react_render_graphics
+  react_render_imagemanager
+  react_render_mapbuffer
+  react_render_textlayoutmanager
+  react_utils
+  react_nativemodule_core
+  rrc_image
+  turbomodulejsijni
+  rrc_text
+  rrc_textinput
+  rrc_view
+  yoga
+)
+
+target_compile_options(
+  ${LIB_TARGET_NAME}
+  PRIVATE
+  -DLOG_TAG=\"ReactNative\"
+  -fexceptions
+  -frtti
+  -std=c++20
+  -Wall
+)
+
+target_include_directories(
+  ${CMAKE_PROJECT_NAME}
+  PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/package/android/src/main/jni/RNCSlider.h
+++ b/package/android/src/main/jni/RNCSlider.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <ReactCommon/JavaTurboModule.h>
+#include <ReactCommon/TurboModule.h>
+#include <jsi/jsi.h>
+#include <react/renderer/components/RNCSlider/RNCSliderComponentDescriptor.h>
+
+namespace facebook {
+namespace react {
+
+JSI_EXPORT
+std::shared_ptr<TurboModule> RNCSlider_ModuleProvider(
+    const std::string &moduleName,
+    const JavaTurboModule::InitParams &params);
+
+} // namespace react
+} // namespace facebook
+

--- a/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -1,11 +1,15 @@
 package com.reactnativecommunity.slider;
 
+import android.content.Context;
+import android.view.View;
 import android.widget.SeekBar;
 import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.common.MapBuilder;
+import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerHelper;
@@ -17,6 +21,8 @@ import java.util.Map;
 import com.facebook.react.viewmanagers.RNCSliderManagerInterface;
 import com.facebook.react.viewmanagers.RNCSliderManagerDelegate;
 import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.yoga.YogaMeasureMode;
+import com.facebook.yoga.YogaMeasureOutput;
 
 /**
  * Manages instances of {@code ReactSlider}.
@@ -190,11 +196,6 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
     view.setOnSeekBarChangeListener(ON_CHANGE_LISTENER);
   }
 
-  @Override
-  public Map getExportedCustomDirectEventTypeConstants() {
-    return ReactSliderManagerImpl.getExportedCustomDirectEventTypeConstants();
-  }
-
   // these props are not available on Android, however we must override their setters
   @Override
   public void setMinimumTrackImage(ReactSlider view, @Nullable ReadableMap readableMap) {}
@@ -210,4 +211,35 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
 
   @Override
   public void setVertical(ReactSlider view, boolean value) {}
+
+  @Override
+  public long measure(
+          Context context,
+          ReadableMap localData,
+          ReadableMap props,
+          ReadableMap state,
+          float width,
+          YogaMeasureMode widthMode,
+          float height,
+          YogaMeasureMode heightMode,
+          @Nullable float[] attachmentsPositions) {
+    ReactSlider view = new ReactSlider(context, null);
+    int measureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
+    view.measure(measureSpec, measureSpec);
+    return YogaMeasureOutput.make(
+            PixelUtil.toDIPFromPixel(view.getMeasuredWidth()),
+            PixelUtil.toDIPFromPixel(view.getMeasuredHeight()));
+  }
+
+    @Nullable
+    @Override
+    public Map<String, Object> getExportedCustomBubblingEventTypeConstants() {
+        return ReactSliderManagerImpl.getExportedCustomBubblingEventTypeConstants();
+    }
+
+    @Nullable
+    @Override
+    public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+        return ReactSliderManagerImpl.getExportedCustomDirectEventTypeConstants();
+    }
 }

--- a/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -200,8 +200,15 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
     view.setOnSeekBarChangeListener(ON_CHANGE_LISTENER);
   }
 
-  @Override
-  public Map getExportedCustomDirectEventTypeConstants() {
-    return ReactSliderManagerImpl.getExportedCustomDirectEventTypeConstants();
-  }
+    @Nullable
+    @Override
+    public Map<String, Object> getExportedCustomBubblingEventTypeConstants() {
+        return ReactSliderManagerImpl.getExportedCustomBubblingEventTypeConstants();
+    }
+
+    @Nullable
+    @Override
+    public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+        return ReactSliderManagerImpl.getExportedCustomDirectEventTypeConstants();
+    }
 }

--- a/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderComponentDescriptor.h
+++ b/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderComponentDescriptor.h
@@ -40,5 +40,5 @@ namespace facebook {
 #endif
         };
 
-    } // namespace react
-} // namespace facebook
+    }
+}

--- a/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderComponentDescriptor.h
+++ b/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderComponentDescriptor.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <react/renderer/components/RNCSlider/RNCSliderShadowNode.h>
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+#include "RNCSliderMeasurementsManager.h"
+
+namespace facebook {
+    namespace react {
+
+        class RNCSliderComponentDescriptor final
+                : public ConcreteComponentDescriptor<RNCSliderShadowNode> {
+#ifdef ANDROID
+        public:
+            RNCSliderComponentDescriptor(const ComponentDescriptorParameters &parameters)
+                    : ConcreteComponentDescriptor(parameters), measurementsManager_(
+                    std::make_shared<RNCSliderMeasurementsManager>(contextContainer_)) {}
+
+            void adopt(ShadowNode &shadowNode) const override {
+                ConcreteComponentDescriptor::adopt(shadowNode);
+
+
+                auto &rncSliderShadowNode =
+                        static_cast<RNCSliderShadowNode &>(shadowNode);
+
+                // `RNCSliderShadowNode` uses `RNCSliderMeasurementsManager` to
+                // provide measurements to Yoga.
+                rncSliderShadowNode.setSliderMeasurementsManager(
+                        measurementsManager_);
+
+                // All `RNCSliderShadowNode`s must have leaf Yoga nodes with properly
+                // setup measure function.
+                rncSliderShadowNode.enableMeasurement();
+            }
+        private:
+            const std::shared_ptr<RNCSliderMeasurementsManager> measurementsManager_;
+#else
+        public:
+            RNCSliderComponentDescriptor(const ComponentDescriptorParameters &parameters)
+            : ConcreteComponentDescriptor(parameters) {}
+#endif
+        };
+
+    } // namespace react
+} // namespace facebook

--- a/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderMeasurementsManager.cpp
+++ b/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderMeasurementsManager.cpp
@@ -1,0 +1,62 @@
+#ifdef ANDROID
+#include "RNCSliderMeasurementsManager.h"
+
+#include <fbjni/fbjni.h>
+#include <react/jni/ReadableNativeMap.h>
+#include <react/renderer/core/conversions.h>
+
+using namespace facebook::jni;
+
+namespace facebook::react {
+
+Size RNCSliderMeasurementsManager::measure(
+    SurfaceId surfaceId,
+    LayoutConstraints layoutConstraints) const {
+  {
+    std::scoped_lock lock(mutex_);
+    if (hasBeenMeasured_) {
+      return cachedMeasurement_;
+    }
+  }
+
+  const jni::global_ref<jobject>& fabricUIManager =
+      contextContainer_->at<jni::global_ref<jobject>>("FabricUIManager");
+
+  static auto measure =
+      jni::findClassStatic("com/facebook/react/fabric/FabricUIManager")
+          ->getMethod<jlong(
+              jint,
+              jstring,
+              ReadableMap::javaobject,
+              ReadableMap::javaobject,
+              ReadableMap::javaobject,
+              jfloat,
+              jfloat,
+              jfloat,
+              jfloat)>("measure");
+
+  auto minimumSize = layoutConstraints.minimumSize;
+  auto maximumSize = layoutConstraints.maximumSize;
+
+  local_ref<JString> componentName = make_jstring("RNCSlider");
+
+  auto measurement = yogaMeassureToSize(measure(
+      fabricUIManager,
+      surfaceId,
+      componentName.get(),
+      nullptr,
+      nullptr,
+      nullptr,
+      minimumSize.width,
+      maximumSize.width,
+      minimumSize.height,
+      maximumSize.height));
+
+  std::scoped_lock lock(mutex_);
+  cachedMeasurement_ = measurement;
+  hasBeenMeasured_ = true;
+  return measurement;
+}
+
+} // namespace facebook::react
+#endif

--- a/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderMeasurementsManager.cpp
+++ b/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderMeasurementsManager.cpp
@@ -58,5 +58,5 @@ Size RNCSliderMeasurementsManager::measure(
   return measurement;
 }
 
-} // namespace facebook::react
+}
 #endif

--- a/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderMeasurementsManager.h
+++ b/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderMeasurementsManager.h
@@ -1,6 +1,4 @@
 #ifdef ANDROID
-#pragma once
-
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/utils/ContextContainer.h>
@@ -21,6 +19,6 @@ namespace facebook::react {
         mutable bool hasBeenMeasured_ = false;
         mutable Size cachedMeasurement_{};
 
-    }; // namespace facebook::react
+    };
 }
 #endif

--- a/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderMeasurementsManager.h
+++ b/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderMeasurementsManager.h
@@ -1,0 +1,26 @@
+#ifdef ANDROID
+#pragma once
+
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+#include <react/renderer/core/LayoutConstraints.h>
+#include <react/utils/ContextContainer.h>
+
+namespace facebook::react {
+
+    class RNCSliderMeasurementsManager {
+    public:
+        RNCSliderMeasurementsManager(
+                const ContextContainer::Shared &contextContainer)
+                : contextContainer_(contextContainer) {}
+
+        Size measure(SurfaceId surfaceId, LayoutConstraints layoutConstraints) const;
+
+    private:
+        const ContextContainer::Shared contextContainer_;
+        mutable std::mutex mutex_;
+        mutable bool hasBeenMeasured_ = false;
+        mutable Size cachedMeasurement_{};
+
+    }; // namespace facebook::react
+}
+#endif

--- a/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderShadowNode.cpp
+++ b/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderShadowNode.cpp
@@ -1,0 +1,27 @@
+#include "RNCSliderShadowNode.h"
+#include "RNCSliderMeasurementsManager.h"
+
+namespace facebook {
+    namespace react {
+
+        extern const char RNCSliderComponentName[] = "RNCSlider";
+
+#ifdef ANDROID
+        void RNCSliderShadowNode::setSliderMeasurementsManager(
+                const std::shared_ptr<RNCSliderMeasurementsManager> &
+                measurementsManager) {
+            ensureUnsealed();
+            measurementsManager_ = measurementsManager;
+        }
+
+#pragma mark - LayoutableShadowNode
+
+        Size RNCSliderShadowNode::measureContent(
+                const LayoutContext & /*layoutContext*/,
+                const LayoutConstraints &layoutConstraints) const {
+            return measurementsManager_->measure(getSurfaceId(), layoutConstraints);
+        }
+#endif
+
+    } // namespace react
+} // namespace facebook

--- a/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderShadowNode.cpp
+++ b/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderShadowNode.cpp
@@ -23,5 +23,5 @@ namespace facebook {
         }
 #endif
 
-    } // namespace react
-} // namespace facebook
+    }
+}

--- a/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderShadowNode.h
+++ b/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderShadowNode.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <jsi/jsi.h>
+#include <react/renderer/components/rncore/EventEmitters.h>
+#include <react/renderer/components/RNCSlider/RNCSliderState.h>
+#include <react/renderer/components/RNCSlider/Props.h>
+#include <react/renderer/components/RNCSlider/EventEmitters.h>
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+
+#include "RNCSliderMeasurementsManager.h"
+
+namespace facebook {
+    namespace react {
+
+        JSI_EXPORT extern const char RNCSliderComponentName[];
+
+/*
+ * `ShadowNode` for <RNCSlider> component.
+ */
+        class JSI_EXPORT RNCSliderShadowNode final
+                : public ConcreteViewShadowNode<
+                        RNCSliderComponentName,
+                        RNCSliderProps,
+                        RNCSliderEventEmitter,
+                        RNCSliderState> {
+        public:
+            using ConcreteViewShadowNode::ConcreteViewShadowNode;
+
+#ifdef ANDROID
+            void setSliderMeasurementsManager(
+                    const std::shared_ptr<RNCSliderMeasurementsManager> &measurementsManager);
+
+#pragma mark - LayoutableShadowNode
+
+            Size measureContent(
+                    const LayoutContext &layoutContext,
+                    const LayoutConstraints &layoutConstraints) const override;
+
+        private:
+            std::shared_ptr<RNCSliderMeasurementsManager> measurementsManager_;
+#endif
+
+        };
+
+    } // namespace react
+} // namespace facebook

--- a/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderShadowNode.h
+++ b/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderShadowNode.h
@@ -42,5 +42,5 @@ namespace facebook {
 
         };
 
-    } // namespace react
-} // namespace facebook
+    }
+}

--- a/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderState.cpp
+++ b/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderState.cpp
@@ -1,0 +1,9 @@
+#include "RNCSliderState.h"
+
+namespace facebook {
+namespace react {
+
+
+
+} // namespace react
+} // namespace facebook

--- a/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderState.cpp
+++ b/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderState.cpp
@@ -1,9 +1,0 @@
-#include "RNCSliderState.h"
-
-namespace facebook {
-namespace react {
-
-
-
-} // namespace react
-} // namespace facebook

--- a/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderState.h
+++ b/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderState.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#ifdef ANDROID
+#include <folly/dynamic.h>
+#include <react/renderer/mapbuffer/MapBuffer.h>
+#include <react/renderer/mapbuffer/MapBufferBuilder.h>
+#endif
+
+namespace facebook {
+namespace react {
+
+class RNCSliderState {
+public:
+  RNCSliderState() = default;
+
+#ifdef ANDROID
+  RNCSliderState(RNCSliderState const &previousState, folly::dynamic data){};
+  folly::dynamic getDynamic() const {
+    return {};
+  };
+  MapBuffer getMapBuffer() const {
+    return MapBufferBuilder::EMPTY();
+  };
+#endif
+};
+
+} // namespace react
+} // namespace facebook

--- a/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderState.h
+++ b/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderState.h
@@ -24,5 +24,5 @@ public:
 #endif
 };
 
-} // namespace react
-} // namespace facebook
+}
+}

--- a/package/ios/RNCSliderComponentView.mm
+++ b/package/ios/RNCSliderComponentView.mm
@@ -4,7 +4,7 @@
 
 #import <React/RCTConversions.h>
 
-#import <react/renderer/components/RNCSlider/ComponentDescriptors.h>
+#import <react/renderer/components/RNCSlider/RNCSliderComponentDescriptor.h>
 #import <react/renderer/components/RNCSlider/EventEmitters.h>
 #import <react/renderer/components/RNCSlider/Props.h>
 #import <react/renderer/components/RNCSlider/RCTComponentViewHelpers.h>

--- a/package/package.json
+++ b/package/package.json
@@ -64,12 +64,11 @@
     "jsxBracketSameLine": true
   },
   "codegenConfig": {
-    "libraries": [
-      {
-        "name": "RNCSlider",
-        "type": "components",
-        "jsSrcsDir": "src"
-      }
-    ]
+    "name": "RNCSlider",
+    "type": "components",
+    "jsSrcsDir": "src",
+    "android": {
+      "javaPackageName": "com.reactnativecommunity.slider"
+    }
   }
 }

--- a/package/react-native-slider.podspec
+++ b/package/react-native-slider.podspec
@@ -3,6 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 Pod::Spec.new do |s|
   s.name         = "react-native-slider"
@@ -16,13 +17,21 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/callstack/react-native-slider.git", :tag => "v#{s.version}" }
   s.source_files = "ios/**/*.{h,m,mm}"
+
+  if new_arch_enabled
+    s.subspec "common" do |ss|
+        ss.source_files         = "common/cpp/**/*.{cpp,h}"
+        ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/common/cpp\"" }
+    end
+  end
+
   if defined?(install_modules_dependencies)
     install_modules_dependencies(s)
   else
     s.dependency 'React-Core'
 
     # This guard prevent to install the dependencies when we run `pod install` in the old architecture.
-    if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
+    if new_arch_enabled then
       s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
       s.pod_target_xcconfig    = {
           "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",

--- a/package/react-native.config.js
+++ b/package/react-native.config.js
@@ -1,0 +1,24 @@
+let supportsCodegenConfig = false;
+try {
+  const rnCliAndroidVersion = require.main.require(
+    '@react-native-community/cli-platform-android/package.json',
+  ).version;
+  const [major] = rnCliAndroidVersion.split('.');
+  supportsCodegenConfig = major >= 9;
+} catch (e) {
+  // ignore
+}
+
+module.exports = {
+  dependency: {
+    platforms: {
+      android: supportsCodegenConfig
+        ? {
+            libraryName: 'RNCSlider',
+            componentDescriptors: ["RNCSliderComponentDescriptor"],
+            cmakeListsPath: 'src/main/jni/CMakeLists.txt',
+          }
+        : {},
+    },
+  },
+};

--- a/package/src/RNCSliderNativeComponent.ts
+++ b/package/src/RNCSliderNativeComponent.ts
@@ -41,6 +41,6 @@ export interface NativeProps extends ViewProps {
   upperLimit?: Float;
 }
 
-export default codegenNativeComponent<NativeProps>(
-  'RNCSlider',
-) as HostComponent<NativeProps>;
+export default codegenNativeComponent<NativeProps>('RNCSlider', {
+  interfaceOnly: true,
+}) as HostComponent<NativeProps>;


### PR DESCRIPTION
Summary:
---------

This PR adds C++ shadow nodes to implement proper measuring for Android on Fabric/Bridgeless.

This code was based on Core implementation: https://github.com/facebook/react-native/blob/2af1da42ff517232f1309efed7565fe9ddbbac77/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchShadowNode.cpp

### Before

![CleanShot 2024-03-28 at 11 50 25@2x](https://github.com/callstack/react-native-slider/assets/52801365/78f14bd8-6891-4d72-8578-1b5abde36c19)

### After

![CleanShot 2024-03-28 at 11 51 00@2x](https://github.com/callstack/react-native-slider/assets/52801365/5c4b15d1-091c-499f-8d8e-04b7ebbbf0c0)


Test Plan:
----------

Check if on new architecture Slider is properly rendered without any styles