### PR TITLE
Fix missing header guard

### DIFF
--- a/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderMeasurementsManager.h
+++ b/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderMeasurementsManager.h
@@ -1,4 +1,6 @@
 #ifdef ANDROID
+#pragma once
+
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/utils/ContextContainer.h>


### PR DESCRIPTION
Summary:
---------
When compiling for the new architecture the build fails on android because of a missing header guard in `RNCSliderMeasurementsManager.h`


Test Plan:
----------
Issue can be reproduced in the example app in the repo.  Adding the guard compiles successfully. 