### PR TITLE
Fix: Linking during Android build for new arch

### DIFF
--- a/.github/workflows/ReactNativeSlider-CI.yml
+++ b/.github/workflows/ReactNativeSlider-CI.yml
@@ -131,7 +131,7 @@ jobs:
           cache-name: cached-gradle-new-arch-prop
         with:
           path: example/android/gradle.properties
-          key: ${{ hashFiles('./example/android/gradle.properties') }}
+          key: gradle-prop-new-arch-config
 
       - name: Build the Android OS app
         run: cd example/android && ./gradlew assembleDebug

--- a/.github/workflows/ReactNativeSlider-CI.yml
+++ b/.github/workflows/ReactNativeSlider-CI.yml
@@ -108,6 +108,33 @@ jobs:
       - name: Build the Android OS app
         run: cd example/android && ./gradlew assembleDebug
 
+  build-android-app-new-arch:
+    name: Build example app Android (Fabric)
+    runs-on: ubuntu-latest
+    needs: [build-android-app]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pull the npm dependencies
+        run: npm install
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Use new arch config
+        id: cache-new-arch-gradle
+        uses: actions/cache@v4
+        env:
+          cache-name: cached-gradle-new-arch-prop
+        with:
+          path: example/android/gradle.properties
+          key: ${{ hashFiles('./example/android/gradle.properties') }}
+
+      - name: Build the Android OS app
+        run: cd example/android && ./gradlew assembleDebug
 
   build-iOS-app:
     name: Build example app iOS

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ build/
 .gradle
 local.properties
 *.iml
+.cxx
 
 # node.js
 #

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -34,7 +34,7 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # your application. You should enable this flag either if you want
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
-newArchEnabled=true
+newArchEnabled=false
 
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -34,7 +34,7 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # your application. You should enable this flag either if you want
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
-newArchEnabled=false
+newArchEnabled=true
 
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.

--- a/package/android/src/main/jni/CMakeLists.txt
+++ b/package/android/src/main/jni/CMakeLists.txt
@@ -51,13 +51,10 @@ target_link_libraries(
   react_render_graphics
   react_render_imagemanager
   react_render_mapbuffer
-  react_render_textlayoutmanager
   react_utils
   react_nativemodule_core
   rrc_image
   turbomodulejsijni
-  rrc_text
-  rrc_textinput
   rrc_view
   yoga
 )

--- a/package/android/src/main/jni/CMakeLists.txt
+++ b/package/android/src/main/jni/CMakeLists.txt
@@ -51,10 +51,13 @@ target_link_libraries(
   react_render_graphics
   react_render_imagemanager
   react_render_mapbuffer
+  react_render_textlayoutmanager
   react_utils
   react_nativemodule_core
   rrc_image
   turbomodulejsijni
+  rrc_text
+  rrc_textinput
   rrc_view
   yoga
 )


### PR DESCRIPTION
This pull request fixes #594 
It basically removes the unused and non-existing libraries from CMake config so that we don't require them when we don't really have them (nor build them on our own).

I briefly checked for the rest of the libs that are included there to see whether there's any other that can be removed, but it seems all other are indeed used and available during the build.

This pull request also introduces the job for building the new arch for Android, so that we can always check whether we are good there.