### PR TITLE
added `value` prop to `StepMarker` component prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To use this library you need to ensure you are using the correct version of Reac
 | `minimumTrackImage` | Assigns a minimum track image. Only static images are supported. The rightmost pixel of the image will be stretched to fill the track. | Image<br/>.propTypes<br/>.source | No | iOS |
 | `thumbImage` | Sets an image for the thumb. Only static images are supported. Needs to be a URI of a local or network image; base64-encoded SVG is not supported. | Image<br/>.propTypes<br/>.source | No | |
 | `trackImage` | Assigns a single image for the track. Only static images are supported. The center pixel of the image will be stretched to fill the track. | Image<br/>.propTypes<br/>.source | No | iOS | |
-| ⚠️ **Experimental:**</br> `StepMarker` | Component to be rendered for each step on the track,<br/>with the possibility to change the styling, when thumb is at that given step | `FC<MarkerProps>`, <br/> where <br/> `MarkerProps`: `{stepMarked: boolean}` | No | iOS, Android, Windows |
+| ⚠️ **Experimental:**</br> `StepMarker` | Component to be rendered for each step on the track,<br/>with the possibility to change the styling, when thumb is at that given step | `FC<MarkerProps>`, <br/> where <br/> `MarkerProps`: `{stepMarked: boolean; value: number}` | No | iOS, Android, Windows |
 | ⚠️ **Experimental:**</br> `renderStepNumber` | Turns on the displaying of numbers of steps.<br/>Numbers of steps are displayed under the track | bool | No | iOS, Android, Windows |
 | `ref` | Reference object. | MutableRefObject | No | web |
 | `View` | [Inherited `View` props...](https://github.com/facebook/react-native-website/blob/master/docs/view.md#props) | | | |

--- a/package/src/components/StepsIndicator.tsx
+++ b/package/src/components/StepsIndicator.tsx
@@ -44,6 +44,7 @@ export const StepsIndicator = ({
             <View style={styles.stepIndicatorElement}>
               <SliderTrackMark
                 key={`${index}-SliderTrackMark`}
+                value={i}
                 isTrue={currentValue === i}
                 thumbImage={thumbImage}
                 StepMarker={StepMarker}

--- a/package/src/components/TrackMark.tsx
+++ b/package/src/components/TrackMark.tsx
@@ -4,22 +4,25 @@ import {styles} from '../utils/styles';
 
 export type MarkerProps = {
   stepMarked: boolean;
+  value: number;
 };
 
 export type TrackMarksProps = {
   isTrue: boolean;
+  value: number;
   thumbImage?: ImageURISource;
   StepMarker?: FC<MarkerProps>;
 };
 
 export const SliderTrackMark = ({
   isTrue,
+  value,
   thumbImage,
   StepMarker,
 }: TrackMarksProps) => {
   return (
     <View style={styles.trackMarkContainer}>
-      {StepMarker ? <StepMarker stepMarked={isTrue} /> : null}
+      {StepMarker ? <StepMarker stepMarked={isTrue} value={value} /> : null}
       {thumbImage && isTrue ? (
         <View style={styles.thumbImageContainer}>
           <Image source={thumbImage} style={styles.thumbImage} />


### PR DESCRIPTION
Summary:
---------

Hello, thanks for the work on the library, it's great! I added a `value` prop to the recently added `StepMarker` prop. This allows developers to render StepMarker conditionally based on their value. This is a small change with a low service area but enables developers to implement features present in other slider libraries (sometimes called [`marks`](https://github.com/react-component/slider/))

My other solution, which would be larger, was making the `StepNumber` component something that could be passed in. Happy to update my PR in that direction if that would be helpful!

Test Plan:
----------

This is a small change, doesn't change any external APIs, and passes all `npm test`s. I have tested it in a web and native app but thought I'd put together a PR to share the changes upstream. Let me know how I can be more helpful on this front!