### PR TITLE
Allow overriding styles

### DIFF
--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -73,7 +73,8 @@ type Props = ViewProps &
      * Used to style and layout the `Slider`.  See `StyleSheet.js` and
      * `DeprecatedViewStylePropTypes.js` for more info.
      */
-    style?: StyleProp<ViewStyle>;
+    containerStyle?: StyleProp<ViewStyle>;
+    sliderStyle?: StyleProp<ViewStyle>;
 
     /**
      * Write-only property representing the value of the slider.
@@ -230,7 +231,7 @@ const SliderComponent = (
   const defaultStyle =
     Platform.OS === 'ios' ? styles.defaultSlideriOS : styles.defaultSlider;
   const sliderStyle = {zIndex: 1, width: width};
-  const style = StyleSheet.compose(props.style, defaultStyle);
+  const style = StyleSheet.compose(props.sliderStyle, defaultStyle);
 
   const onValueChangeEvent = (event: Event) => {
     onValueChange && onValueChange(event.nativeEvent.value);
@@ -287,7 +288,7 @@ const SliderComponent = (
       onLayout={(event) => {
         setWidth(event.nativeEvent.layout.width);
       }}
-      style={[styles, style, {justifyContent: 'center'}]}>
+      style={[styles.containerStyle, props.containerStyle]}>
       {props.StepMarker || !!props.renderStepNumber ? (
         <StepsIndicator
           options={options}
@@ -314,9 +315,9 @@ const SliderComponent = (
         }
         ref={forwardedRef}
         style={[
-          sliderStyle,
-          defaultStyle,
-          {alignContent: 'center', alignItems: 'center'},
+          styles.sliderStyle,
+          {width: width},
+          props.sliderStyle
         ]}
         onChange={onValueChangeEvent}
         onRNCSliderSlidingStart={onSlidingStartEvent}

--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -228,11 +228,6 @@ const SliderComponent = (
     (_, index) => localProps.minimumValue! + index * step,
   );
 
-  const defaultStyle =
-    Platform.OS === 'ios' ? styles.defaultSlideriOS : styles.defaultSlider;
-  const sliderStyle = {zIndex: 1, width: width};
-  const style = StyleSheet.compose(props.sliderStyle, defaultStyle);
-
   const onValueChangeEvent = (event: Event) => {
     onValueChange && onValueChange(event.nativeEvent.value);
     setCurrentValue(event.nativeEvent.value);

--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -2,7 +2,6 @@ import React, {useState} from 'react';
 import {
   Image,
   Platform,
-  StyleSheet,
   AccessibilityActionEvent,
   ViewProps,
   ViewStyle,
@@ -309,11 +308,7 @@ const SliderComponent = (
             : Image.resolveAssetSource(props.thumbImage)
         }
         ref={forwardedRef}
-        style={[
-          styles.sliderStyle,
-          {width: width},
-          props.sliderStyle
-        ]}
+        style={[styles.sliderStyle, {width: width}, props.sliderStyle]}
         onChange={onValueChangeEvent}
         onRNCSliderSlidingStart={onSlidingStartEvent}
         onRNCSliderSlidingComplete={onSlidingCompleteEvent}

--- a/package/src/utils/styles.ts
+++ b/package/src/utils/styles.ts
@@ -3,13 +3,13 @@ import {Platform, StyleSheet} from 'react-native';
 export const styles = StyleSheet.create({
   containerStyle: {
     justifyContent: 'center',
-    height: Platform.OS === 'ios' ? 40 : undefined
+    height: Platform.OS === 'ios' ? 40 : undefined,
   },
   sliderStyle: {
     alignContent: 'center',
     alignItems: 'center',
     zIndex: 1,
-    height: Platform.OS === 'ios' ? 40 : undefined
+    height: Platform.OS === 'ios' ? 40 : undefined,
   },
   stepNumber: {
     marginTop: 20,
@@ -47,5 +47,4 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
     alignContent: 'center',
   },
-
 });

--- a/package/src/utils/styles.ts
+++ b/package/src/utils/styles.ts
@@ -6,7 +6,6 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
     position: 'absolute',
   },
-  sliderMainContainer: {zIndex: 1, width: '100%'},
   defaultSlideriOS: {
     height: 40,
   },
@@ -41,15 +40,5 @@ export const styles = StyleSheet.create({
   stepIndicatorElement: {
     alignItems: 'center',
     alignContent: 'center',
-  },
-  defaultIndicatorMarked: {
-    height: 20,
-    width: 5,
-    backgroundColor: '#CCCCCC',
-  },
-  defaultIndicatorIdle: {
-    height: 10,
-    width: 2,
-    backgroundColor: '#C0C0C0',
   },
 });

--- a/package/src/utils/styles.ts
+++ b/package/src/utils/styles.ts
@@ -1,15 +1,21 @@
 import {Platform, StyleSheet} from 'react-native';
 
 export const styles = StyleSheet.create({
+  containerStyle: {
+    justifyContent: 'center',
+    height: Platform.OS === 'ios' ? 40 : undefined
+  },
+  sliderStyle: {
+    alignContent: 'center',
+    alignItems: 'center',
+    zIndex: 1,
+    height: Platform.OS === 'ios' ? 40 : undefined
+  },
   stepNumber: {
     marginTop: 20,
     alignItems: 'center',
     position: 'absolute',
   },
-  defaultSlideriOS: {
-    height: 40,
-  },
-  defaultSlider: {},
   stepsIndicator: {
     flex: 1,
     flexDirection: 'row',
@@ -41,4 +47,5 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
     alignContent: 'center',
   },
+
 });

--- a/package/typings/index.d.ts
+++ b/package/typings/index.d.ts
@@ -137,7 +137,8 @@ export interface SliderProps
   /**
    * Used to style and layout the Slider. See StyleSheet.js and ViewStylePropTypes.js for more info.
    */
-  style?: ReactNative.StyleProp<ReactNative.ViewStyle>;
+  containerStyle?: ReactNative.StyleProp<ReactNative.ViewStyle>;
+  sliderStyle?: ReactNative.StyleProp<ReactNative.ViewStyle>;
 
   /**
    * Used to locate this view in UI automation tests.


### PR DESCRIPTION
When trying to set the style property, the react-native-slider library will override height with default styles. This change allows modifying both the container and slider styles individually.