### PR TITLE
fix: set default initial value on web

### DIFF
--- a/package/src/RNCSliderNativeComponent.web.tsx
+++ b/package/src/RNCSliderNativeComponent.web.tsx
@@ -53,7 +53,7 @@ const valueToEvent = (value: number): Event => ({nativeEvent: {value}});
 const RCTSliderWebComponent = React.forwardRef(
   (
     {
-      value: initialValue,
+      value: initialValue = 0,
       minimumValue = 0,
       maximumValue = 0,
       lowerLimit = 0,


### PR DESCRIPTION
Summary:
---------
Referencing this issue: #617
React native web implementation had no default value set for initial value therefore resulting in such issues.
According to mobile implementation and documentation set the default value for initialValue prop to be 0.

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

Verified on controlled examples from example-web by setting initial useState value to undefined