### PR TITLE
chore: add info about current compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,13 @@ import Slider from '@react-native-community/slider';
 To use this library you need to ensure you are using the correct version of React Native.
 
 | `@react-native-community/slider` version | Required React Native Version |
-| ---------------------------------------- | ----------------------------- |
-| `4.3.0`                                  | `>=0.64`                      |
-| `4.x.x`                                  | `>=0.60`; `>=0.62` (on Windows);  |
-| `3.1.x`                                  | `>=0.60`                      |
-| `2.x.x`                                  | `>= 0.60`                     |
-| [`1.x.x`](https://github.com/react-native-community/react-native-slider/tree/937f0942f1fffc6ed88b5cf7c88d73b7878f00f0)  | `<= 0.59` |
+| ---------------------------------------- | ---------------------------- |
+| `4.5.1`                                  | `>=0.69`                     |
+| `4.3.0`                                  | `>=0.64`                     |
+| `4.x.x`                                  | `>=0.60`; `>=0.62` (on Windows); |
+| `3.1.x`                                  | `>=0.60`                     |
+| `2.x.x`                                  | `>= 0.60`                    |
+| [`1.x.x`](https://github.com/react-native-community/react-native-slider/tree/937f0942f1fffc6ed88b5cf7c88d73b7878f00f0) | `<= 0.59` |
 
 
 ## Properties


### PR DESCRIPTION
Summary:
---------
Regarding issue #596 
Recent upgrade of supported RN version removes support for versions older than RN 69, meaning that last compatible version of library is 4.5.0

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

No tests required