### PR TITLE
fix: remove additional onchange event in onStopTrackingTouch

### DIFF
--- a/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -86,11 +86,6 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
                               reactTag,
                               ((ReactSlider)seekbar).toRealProgress(seekbar.getProgress()))
               );
-              eventDispatcher.dispatchEvent(
-                      new ReactSliderEvent(
-                              reactTag,
-                              ((ReactSlider)seekbar).toRealProgress(seekbar.getProgress()),
-                              !((ReactSlider)seekbar).isSliding()));
             }
           };
 

--- a/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -65,11 +65,6 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
                       new ReactSlidingCompleteEvent(
                               seekbar.getId(),
                               ((ReactSlider)seekbar).toRealProgress(seekbar.getProgress())));
-              reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
-                      new ReactSliderEvent(
-                              seekbar.getId(),
-                              ((ReactSlider)seekbar).toRealProgress(seekbar.getProgress()),
-                              !((ReactSlider)seekbar).isSliding()));
             }
           };
 
@@ -77,7 +72,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
   public String getName() {
     return ReactSliderManagerImpl.REACT_CLASS;
   }
-  
+
   static class ReactSliderShadowNode extends LayoutShadowNode implements
       YogaMeasureFunction {
 


### PR DESCRIPTION
Summary:
---------
closes #569 
In Seekbar overriden method onStopTrackingTouch was emitting two events - which might caused unwanted emission of onValueChange, removing this seems to not break any logic or behaviour but fixes the problem described.
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
I have ran the example app on old arch and all examples seems to work correctly
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->