### PR TITLE
feat: custom padding on android

### DIFF
--- a/example/src/Examples.tsx
+++ b/example/src/Examples.tsx
@@ -433,6 +433,11 @@ const styles = StyleSheet.create({
     borderRadius: 1,
     backgroundColor: '#334488',
   },
+  noPaddingContainer: {
+    backgroundColor: '#645f5f',
+    borderRadius: 4,
+    paddingVertical: 8,
+  },
 });
 
 export const examples: Props[] = [
@@ -458,6 +463,23 @@ export const examples: Props[] = [
     title: 'step: 0.25, tap to seek on iOS',
     render(): React.ReactElement {
       return <SliderExample step={0.25} tapToSeek={true} />;
+    },
+  },
+  {
+    title: 'Custom padding on Android',
+    render(): React.ReactElement {
+      return (
+        <View style={styles.noPaddingContainer}>
+          <SliderExample
+            padding={{
+              left: 0,
+              right: 0,
+            }}
+            step={0.25}
+            tapToSeek={true}
+          />
+        </View>
+      );
     },
   },
   {

--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManagerImpl.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManagerImpl.java
@@ -35,6 +35,10 @@ public class ReactSliderManagerImpl {
         return slider;
     }
 
+    public static void setPadding(ReactSlider view, int left, int top, int right, int bottom) {
+       view.setPadding(left, top, right, bottom);
+    }
+
     public static void setValue(ReactSlider view, double value) {
         if (view.isSliding() == false) {
             view.setValue(value);

--- a/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -105,6 +105,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
     ReactSliderManagerImpl.setDisabled(view, disabled);
   }
 
+
   @Override
   @ReactProp(name = "value", defaultFloat = 0f)
   public void setValue(ReactSlider view, float value) {
@@ -163,6 +164,18 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
   @ReactProp(name = "accessibilityIncrements")
   public void setAccessibilityIncrements(ReactSlider view, ReadableArray accessibilityIncrements) {
     ReactSliderManagerImpl.setAccessibilityIncrements(view, accessibilityIncrements);
+  }
+
+  @ReactProp(name = "padding")
+  public void setPadding(ReactSlider view, ReadableMap paddingMap) {
+      if (paddingMap != null) {
+          int left = paddingMap.hasKey("left") ? paddingMap.getInt("left") : view.getPaddingLeft();
+          int top = paddingMap.hasKey("top") ? paddingMap.getInt("top") : view.getPaddingTop();
+          int right = paddingMap.hasKey("right") ? paddingMap.getInt("right") : view.getPaddingRight();
+          int bottom = paddingMap.hasKey("bottom") ? paddingMap.getInt("bottom") : view.getPaddingBottom();
+
+          ReactSliderManagerImpl.setPadding(view, left, top, right, bottom);
+      }
   }
 
   @ReactProp(name = "lowerLimit")

--- a/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -140,6 +140,18 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
     ReactSliderManagerImpl.setMaximumValue(view, value);
   }
 
+   @ReactProp(name = "padding")
+    public void setPadding(ReactSlider view, ReadableMap paddingMap) {
+        if (paddingMap != null) {
+            int left = paddingMap.hasKey("left") ? paddingMap.getInt("left") : view.getPaddingLeft();
+            int top = paddingMap.hasKey("top") ? paddingMap.getInt("top") : view.getPaddingTop();
+            int right = paddingMap.hasKey("right") ? paddingMap.getInt("right") : view.getPaddingRight();
+            int bottom = paddingMap.hasKey("bottom") ? paddingMap.getInt("bottom") : view.getPaddingBottom();
+
+            ReactSliderManagerImpl.setPadding(view, left, top, right, bottom);
+        }
+    }
+
   @ReactProp(name = "lowerLimit")
   public void setLowerLimit(ReactSlider view, float value) {
     ReactSliderManagerImpl.setLowerLimit(view, value);

--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -197,6 +197,17 @@ type Props = ViewProps &
      * The number of elements must be the same as `maximumValue`.
      */
     accessibilityIncrements?: Array<string>;
+
+    /**
+     * Android Only.
+     * Custom padding configuration
+     */
+    padding?: {
+      left?: number;
+      top?: number;
+      right?: number;
+      bottom?: number;
+    };
   }>;
 
 const SliderComponent = (

--- a/package/typings/index.d.ts
+++ b/package/typings/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { FC } from 'react';
+import {FC} from 'react';
 import * as ReactNative from 'react-native';
-import { ImageURISource } from 'react-native';
+import {ImageURISource} from 'react-native';
 
 type Constructor<T> = new (...args: any[]) => T;
 
@@ -114,6 +114,16 @@ export interface SliderProps
   minimumValue?: number;
 
   /**
+   * Custom padding on android
+   */
+  padding?: {
+    left?: number;
+    top?: number;
+    right?: number;
+    bottom?: number;
+  };
+
+  /**
    * Callback that is called when the user picks up the slider.
    * The initial value is passed as an argument to the callback handler.
    */
@@ -168,7 +178,7 @@ export interface SliderProps
   StepMarker?: FC<MarkerProps>;
 
   /**
-   * 
+   *
    */
   renderStepNumber?: boolean;
 


### PR DESCRIPTION
Summary:
---------
fixes #98 
Allow user to set custom padding for the android slider, no effect on iOS
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
Added new example presenting the slider with custom padding 0 set horizontally for slider allowing to slide from end to end
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->