### PR TITLE
Fixed wrong usage of require when resolving supportsCodegenConfig in react-native.config.js

### DIFF
--- a/package/react-native.config.js
+++ b/package/react-native.config.js
@@ -1,24 +1,11 @@
-let supportsCodegenConfig = false;
-try {
-  const rnCliAndroidVersion = require(
-    '@react-native-community/cli-platform-android/package.json',
-  ).version;
-  const [major] = rnCliAndroidVersion.split('.');
-  supportsCodegenConfig = major >= 9;
-} catch (e) {
-  // ignore
-}
-
 module.exports = {
   dependency: {
     platforms: {
-      android: supportsCodegenConfig
-        ? {
-            libraryName: 'RNCSlider',
-            componentDescriptors: ["RNCSliderComponentDescriptor"],
-            cmakeListsPath: 'src/main/jni/CMakeLists.txt',
-          }
-        : {},
+      android: {
+        libraryName: 'RNCSlider',
+        componentDescriptors: ['RNCSliderComponentDescriptor'],
+        cmakeListsPath: 'src/main/jni/CMakeLists.txt',
+      },
     },
   },
 };

--- a/package/react-native.config.js
+++ b/package/react-native.config.js
@@ -1,6 +1,6 @@
 let supportsCodegenConfig = false;
 try {
-  const rnCliAndroidVersion = require.main.require(
+  const rnCliAndroidVersion = require(
     '@react-native-community/cli-platform-android/package.json',
   ).version;
   const [major] = rnCliAndroidVersion.split('.');


### PR DESCRIPTION
Summary:
---------

When using the library in monorepo solutions or other non-standard types of projects the Slider will end up with a height of 0 and not work. (See #652)

Problem/fix:
-----------

When resolving the version inside `react-native-config` which is used by the autolinking gradle tasks, the wrong use of require was used.

This fix changes from using `require.main.require` -> `require`.

The difference is that require.main.require resolves from the entry point (main script), while require resolves from the location of the current file.
Fixes (partially) #652

Test Plan:
----------

See #652 for reproduction and tests. We've tested in in our BareExpo project, in a regular project (where it also previously did work) and in a project using react-native-test-app (https://github.com/vonovak/react-native-slider/tree/fix/new-arch-issues/new-example)