### PR TITLE
fix: unblock build for 0.76

### DIFF
--- a/package/android/src/main/jni/CMakeLists.txt
+++ b/package/android/src/main/jni/CMakeLists.txt
@@ -37,27 +37,38 @@ target_include_directories(
   ${LIB_ANDROID_GENERATED_COMPONENTS_DIR}
 )
 
-target_link_libraries(
-  ${LIB_TARGET_NAME}
-  fbjni
-  folly_runtime
-  glog
-  jsi
-  react_codegen_rncore
-  react_debug
-  react_render_componentregistry
-  react_render_core
-  react_render_debug
-  react_render_graphics
-  react_render_imagemanager
-  react_render_mapbuffer
-  react_utils
-  react_nativemodule_core
-  rrc_image
-  turbomodulejsijni
-  rrc_view
-  yoga
-)
+# https://github.com/react-native-community/discussions-and-proposals/discussions/816
+# This if-then-else can be removed once this library does not support version below 0.76
+if (REACTNATIVE_MERGED_SO)
+  target_link_libraries(
+    ${LIB_TARGET_NAME}
+    fbjni
+    jsi
+    reactnative
+  )
+else()
+  target_link_libraries(
+    ${LIB_TARGET_NAME}
+    fbjni
+    folly_runtime
+    glog
+    jsi
+    react_codegen_rncore
+    react_debug
+    react_render_componentregistry
+    react_render_core
+    react_render_debug
+    react_render_graphics
+    react_render_imagemanager
+    react_render_mapbuffer
+    react_utils
+    react_nativemodule_core
+    rrc_image
+    turbomodulejsijni
+    rrc_view
+    yoga
+  )
+endif()
 
 target_compile_options(
   ${LIB_TARGET_NAME}


### PR DESCRIPTION
Summary:
---------

the recently released 4.5.4 won't build when installed into a RN 0.76 project, due to breaking changes described in https://github.com/react-native-community/discussions-and-proposals/discussions/816

This PR fixes the build in a backward-compatible way, as recommended in the link above

the build failure:

```
C/C++: /Users/vojta/_dev/expo/node_modules/@react-native-community/slider/android/src/main/jni/../../../build/generated/source/codegen/jni/react/renderer/components/RNCSlider/EventEmitters.h:12:10: fatal error: 'react/renderer/components/view/ViewEventEmitter.h' file not found
C/C++: #include <react/renderer/components/view/ViewEventEmitter.h>
C/C++:          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C/C++: 1 error generated.
C/C++:
```

and a bunch more of the same kind


Test Plan:
----------

tested inside my fork at https://github.com/vonovak/react-native-slider/tree/fix/new-arch-issues

I used `"react-native-test-app": "^3.10.15", "react-native": "0.76.0-rc.5"`