### PR TITLE
fix: ios inverted tap to seek in rtl

### DIFF
--- a/package/ios/RNCSliderComponentView.mm
+++ b/package/ios/RNCSliderComponentView.mm
@@ -77,7 +77,14 @@ using namespace facebook::react;
 
     CGPoint touchPoint = [gesture locationInView:slider];
     float rangeWidth = slider.maximumValue - slider.minimumValue;
-    float sliderPercent = touchPoint.x / slider.bounds.size.width;
+    
+    float sliderPercent;
+    if ([UIView userInterfaceLayoutDirectionForSemanticContentAttribute:slider.semanticContentAttribute] == UIUserInterfaceLayoutDirectionRightToLeft) {
+        sliderPercent = 1.0 - (touchPoint.x / slider.bounds.size.width);
+    } else {
+        sliderPercent = touchPoint.x / slider.bounds.size.width;
+    }
+
     slider.lastValue = slider.value;
     float value = slider.minimumValue + (rangeWidth * sliderPercent);
 

--- a/package/ios/RNCSliderManager.m
+++ b/package/ios/RNCSliderManager.m
@@ -57,7 +57,14 @@ RCT_EXPORT_MODULE()
 
   CGPoint touchPoint = [gesture locationInView:slider];
   float rangeWidth = slider.maximumValue - slider.minimumValue;
-  float sliderPercent = touchPoint.x / slider.bounds.size.width;
+      
+  float sliderPercent;
+  if ([UIView userInterfaceLayoutDirectionForSemanticContentAttribute:slider.semanticContentAttribute] == UIUserInterfaceLayoutDirectionRightToLeft) {
+      sliderPercent = 1.0 - (touchPoint.x / slider.bounds.size.width);
+  } else {
+      sliderPercent = touchPoint.x / slider.bounds.size.width;
+  }
+
   slider.lastValue = slider.value;
   float value = slider.minimumValue + (rangeWidth * sliderPercent);
 


### PR DESCRIPTION
Summary:
---------

When `tapToSeek` option is enabled it works as expected on LTR, however after changing the application to RTL it seeks to the inverted tap location.

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

Test Plan:
----------

Before:

https://github.com/user-attachments/assets/61192081-7f05-4250-a052-2832dbb460da


After:

https://github.com/user-attachments/assets/832a03e6-e790-4c15-a5f4-c6a47946f8ec

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->