### PR TITLE
feat: add component provider field for codegen

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -77,6 +77,11 @@
     "jsSrcsDir": "src",
     "android": {
       "javaPackageName": "com.reactnativecommunity.slider"
+    },
+    "ios": {
+      "componentProvider": {
+        "RNCSlider": "RNCSliderComponentView"
+      }
     }
   }
 }


### PR DESCRIPTION
Summary:
---------

When installing this package with RN 0.77 there's a warning related to the missing field in `codegenConfig`:

```
[Codegen] [DEPRECATED] @react-native-community/slider should add the 'ios.componentProvider' property in their codegenConfig
```

This PR fixes it 👍

Test Plan:
----------

1. Create an app with RN 0.77
2. Apply diff
3. Install Cocoapods