### PR TITLE
change ReactProp to defaultDouble

### DIFF
--- a/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -107,19 +107,19 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
   }
 
   @Override
-  @ReactProp(name = "minimumValue", defaultFloat = 0f)
+  @ReactProp(name = "minimumValue", defaultDouble = 0d)
   public void setMinimumValue(ReactSlider view, double value) {
     ReactSliderManagerImpl.setMinimumValue(view, value);
   }
 
   @Override
-  @ReactProp(name = "maximumValue", defaultFloat = 0f)
+  @ReactProp(name = "maximumValue", defaultDouble = 0d)
   public void setMaximumValue(ReactSlider view, double value) {
     ReactSliderManagerImpl.setMaximumValue(view, value);
   }
 
   @Override
-  @ReactProp(name = "step", defaultFloat = 0f)
+  @ReactProp(name = "step", defaultDouble = 0d)
   public void setStep(ReactSlider view, double value) {
     ReactSliderManagerImpl.setStep(view, value);
   }


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

no functionality change just make API consistent.

The change to https://github.com/callstack/react-native-slider/pull/649/files#diff-e1ce4a6b5a58885eafa4615c2f0835fb1561080fcbcffb2ac8ac50fd0fb3bbaa

changed the `value` parameter from `float` to `double` type

but the `@ReactProp` annotation still uses float. This PR changes it to `defaultDouble` to be consistent

`double` type for both annotation and `value` parameter type

Extra:
-----

1. the oldarch has 

``` 
@ReactProp(name = "maximumValue", defaultDouble = 1d)
```

should we also default to `1d` for `setMaximumValue` ?

https://github.com/callstack/react-native-slider/blob/f458a1c9451c1e5d8a40593f02a0c76bae18e560/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java#L133-L136


2. Why is `ReactSliderManager.setValue` still accepts a `float` type for `value` when the underlying implementation accepts a `double`?

https://github.com/callstack/react-native-slider/blob/f458a1c9451c1e5d8a40593f02a0c76bae18e560/package/android/src/main/java/com/reactnativecommunity/slider/ReactSliderManagerImpl.java#L38-L45

should we also change the param type for `value` to `double` ?