### PR TITLE
Update RNCSliderComponentView.mm

### DIFF
--- a/package/ios/RNCSliderComponentView.mm
+++ b/package/ios/RNCSliderComponentView.mm
@@ -218,7 +218,7 @@ using namespace facebook::react;
         slider.accessibilityUnits = convertedAccessibilityUnits;
     }
     if (oldScreenProps.accessibilityIncrements != newScreenProps.accessibilityIncrements) {
-        id accessibilityIncrements = [NSArray new];
+        id accessibilityIncrements = [NSMutableArray new];
         for (auto str : newScreenProps.accessibilityIncrements) {
             [accessibilityIncrements addObject:[NSString stringWithUTF8String:str.c_str()]];
         }


### PR DESCRIPTION
Summary:
---------

This fixes a NSInvalidArgumentException which causes a full app crash when `<Slider accessibilityIncrements={['anything non-empty array']} />` is rendered, by initializing an NSMutableArray instead of an NSArray, as it called with `addObject:` if `accessibilityIncrements` is non-empty.

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
In iOS,

Render `<Slider minimumValue={1} maximumValue={3} accessibilityIncrements={['alfa', 'bravo', 'charlie']} />`

See if it crashes or not

----

Android should have no behavioral differences.