### PR TITLE
Remove migration instruction and link the Slider channel on Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,23 +51,6 @@ import Slider from '@react-native-community/slider';
 
 Check out the [example project](example) for more examples.
 
----
-
-**Migrating from the core `react-native` module**
-
-This module was created when the Slider was split out from the core of React Native.
-<br/>To migrate to this module you need to follow the installation instructions above and then change you imports from:
-
-```javascript
-import { Slider } from 'react-native';
-```
-
-to:
-
-```javascript
-import Slider from '@react-native-community/slider';
-```
-
 ## React Native Compatibility
 To use this library you need to ensure you are using the correct version of React Native.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ import Slider from '@react-native-community/slider';
 
 Check out the [example project](example) for more examples.
 
+### Reach out on Discord
+
+If you have any questions, issues or any other topic that you need an advise in, reach out to us on our channel on Discord under this 👉 [link](https://discord.com/channels/426714625279524876/1339942689524678737).
+<br/>See you there!
+
 ## React Native Compatibility
 To use this library you need to ensure you are using the correct version of React Native.
 


### PR DESCRIPTION
This pull request
* removes the migration part from README
I didn't find it any longer required, as this package is here for some time (years) now and settled down pretty well already.
* adds the official channel on Discord, where community can ask questions, issues, ping devs, etc.