### PR TITLE
fix: android auto increment on new arch

### DIFF
--- a/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -52,10 +52,10 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
               seekbar.setProgress(progress);
 
               ReactContext reactContext = (ReactContext) seekbar.getContext();
-              if(fromUser){
+              if (fromUser) {
                 int reactTag = seekbar.getId();
                 UIManagerHelper.getEventDispatcherForReactTag(reactContext, reactTag)
-                        .dispatchEvent(new ReactSliderEvent(reactTag, slider.toRealProgress(progress), true));
+                      .dispatchEvent(new ReactSliderEvent(reactTag, slider.toRealProgress(progress), true));
               }
             }
 

--- a/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/package/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -52,9 +52,11 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
               seekbar.setProgress(progress);
 
               ReactContext reactContext = (ReactContext) seekbar.getContext();
-              int reactTag = seekbar.getId();
-              UIManagerHelper.getEventDispatcherForReactTag(reactContext, reactTag)
-                      .dispatchEvent(new ReactSliderEvent(reactTag, slider.toRealProgress(progress), fromUser));
+              if(fromUser){
+                int reactTag = seekbar.getId();
+                UIManagerHelper.getEventDispatcherForReactTag(reactContext, reactTag)
+                        .dispatchEvent(new ReactSliderEvent(reactTag, slider.toRealProgress(progress), true));
+              }
             }
 
             @Override


### PR DESCRIPTION
Summary:
---------

Fix android auto increment issued on new arch (See [#683](https://github.com/callstack/react-native-slider/issues/683)). 

Added same check `if(fromUser)` that is present in the old architecture.

https://github.com/callstack/react-native-slider/blob/e9084f6adcd32e39cda62322a8209f6ac098a33f/package/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java#L37-L42


Test Plan:
----------
Used [#683](https://github.com/callstack/react-native-slider/issues/683) as a template for bare react native project, to reproduce the issue and  check if it is still present. 

| Before  | After  |
|---------|--------|
| ![Before](https://github.com/user-attachments/assets/b5cdf984-0f8e-4b2e-9791-505452e5d0d8) | ![After](https://github.com/user-attachments/assets/27700599-de94-42ce-9062-5f45a2d4f339) |


<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->