### PR TITLE
fix: do not ignore 0 value prop

### DIFF
--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -211,7 +211,7 @@ const SliderComponent = (
     ...localProps
   } = props;
   const [currentValue, setCurrentValue] = useState(
-    props.value || props.minimumValue || constants.SLIDER_DEFAULT_INITIAL_VALUE,
+    props.value ?? props.minimumValue ?? constants.SLIDER_DEFAULT_INITIAL_VALUE,
   );
   const [width, setWidth] = useState(0);
 


### PR DESCRIPTION
Summary:
---------

``currentValue`` is used when rendering `StepMarker` and currently it doesn't seem to treat 0 correctly.

Test Plan:
----------

```
  const renderStepMarker = React.useCallback(({ stepMarked, currentValue }: MarkerProps) => {
    return stepMarked ? <Text>{currentValue}</Text> : null;
  }, []);

<Slider
  minimumValue={-3}
  value={0}
  maximumValue={5}
  onValueChange={setValue}
  StepMarker={renderStepMarker}
/>
```

<details>
<summary>Details</summary>

![simulator_screenshot_B9622E5F-8FDB-4697-82E2-819E5D318160](https://github.com/user-attachments/assets/5b23470b-d2e2-4088-ac7c-bfe0fcd9a614)

</details>



previously:


<details>
<summary>Details</summary>

![simulator_screenshot_61C1DFA5-D7A3-46B6-862A-4DADFAB6FCB3](https://github.com/user-attachments/assets/3d86629a-4a15-4e1a-bf01-9d471463524b)

</details>



