### PR TITLE
Fix styles order

### DIFF
--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -233,7 +233,7 @@ const SliderComponent = (
   const defaultStyle =
     Platform.OS === 'ios' ? styles.defaultSlideriOS : styles.defaultSlider;
   const sliderStyle = {zIndex: 1, width: width};
-  const style = [props.style, defaultStyle];
+  const style = [defaultStyle, props.style];
 
   const onValueChangeEvent = (event: Event) => {
     onValueChange && onValueChange(event.nativeEvent.value);

--- a/package/src/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/package/src/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`<Slider /> accessibilityState disabled sets disabled={true} 1`] = `
   style={
     [
       [
-        undefined,
         {
           "height": 40,
         },
+        undefined,
       ],
       {
         "justifyContent": "center",
@@ -63,10 +63,10 @@ exports[`<Slider /> disabled prop overrides accessibilityState.disabled 1`] = `
   style={
     [
       [
-        undefined,
         {
           "height": 40,
         },
+        undefined,
       ],
       {
         "justifyContent": "center",
@@ -120,10 +120,10 @@ exports[`<Slider /> disabled prop overrides accessibilityState.enabled 1`] = `
   style={
     [
       [
-        undefined,
         {
           "height": 40,
         },
+        undefined,
       ],
       {
         "justifyContent": "center",
@@ -177,10 +177,10 @@ exports[`<Slider /> renders a slider with custom props 1`] = `
   style={
     [
       [
-        undefined,
         {
           "height": 40,
         },
+        undefined,
       ],
       {
         "justifyContent": "center",
@@ -233,10 +233,10 @@ exports[`<Slider /> renders a slider with custom stepMaker 1`] = `
   style={
     [
       [
-        undefined,
         {
           "height": 40,
         },
+        undefined,
       ],
       {
         "justifyContent": "center",
@@ -32337,10 +32337,10 @@ exports[`<Slider /> renders disabled slider 1`] = `
   style={
     [
       [
-        undefined,
         {
           "height": 40,
         },
+        undefined,
       ],
       {
         "justifyContent": "center",
@@ -32394,10 +32394,10 @@ exports[`<Slider /> renders enabled slider 1`] = `
   style={
     [
       [
-        undefined,
         {
           "height": 40,
         },
+        undefined,
       ],
       {
         "justifyContent": "center",


### PR DESCRIPTION
Summary:
---------
When applying styles to the `Slider`, some styles are overwritten by the `defaultStyles`. This can lead to behaviour which the user does not expect. Closes #680 


Test Plan:
----------

1. Run the example app with no changes
2. Observe the slider components
3. Add a `style` prop with `height: 40` to any of the examples
4. Observe the height property is applied correctly to the slider