### PR TITLE
fix: lock react on 19.0.0 for example project

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@react-native-community/slider": "file:../package",
         "babel-preset-expo": "^9.2.0",
-        "react": "^19.0.0",
+        "react": "19.0.0",
         "react-native": "^0.79.2",
         "react-native-pager-view": "^6.6.0"
       },
@@ -11399,9 +11399,10 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/example/package.json
+++ b/example/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@react-native-community/slider": "file:../package",
     "babel-preset-expo": "^9.2.0",
-    "react": "^19.0.0",
+    "react": "19.0.0",
     "react-native": "^0.79.2",
     "react-native-pager-view": "^6.6.0"
   },


### PR DESCRIPTION
Summary:
---------
I have noticed during last tests that local version of example app was throwing error in console regarding mismatch between React and React Native renderer version, cause we had loose assign in dependencies for React - so it installed on clear setup the 19.1.0 instead of expected for this React Native version React 19.0.0

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
Run android version locally on clear node_modules, check console - no errors should be seen
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->