### PR TITLE
fix: support for react native 0.81 on Android

### DIFF
--- a/package/android/src/main/jni/CMakeLists.txt
+++ b/package/android/src/main/jni/CMakeLists.txt
@@ -9,15 +9,6 @@ set(LIB_COMMON_DIR ${LIB_ANDROID_DIR}/../common/cpp)
 set(LIB_ANDROID_GENERATED_JNI_DIR ${LIB_ANDROID_DIR}/build/generated/source/codegen/jni)
 set(LIB_ANDROID_GENERATED_COMPONENTS_DIR ${LIB_ANDROID_GENERATED_JNI_DIR}/react/renderer/components/${LIB_LITERAL})
 
-add_compile_options(
-  -fexceptions
-  -frtti
-  -std=c++20
-  -Wall
-  -Wpedantic
-  -Wno-gnu-zero-variadic-macro-arguments
-)
-
 file(GLOB LIB_CUSTOM_SRCS CONFIGURE_DEPENDS *.cpp ${LIB_COMMON_DIR}/react/renderer/components/${LIB_LITERAL}/*.cpp)
 file(GLOB LIB_CODEGEN_SRCS CONFIGURE_DEPENDS ${LIB_ANDROID_GENERATED_JNI_DIR}/*.cpp ${LIB_ANDROID_GENERATED_COMPONENTS_DIR}/*.cpp)
 
@@ -67,6 +58,21 @@ else()
     turbomodulejsijni
     rrc_view
     yoga
+  )
+endif()
+
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 81)
+  target_compile_reactnative_options(${LIB_TARGET_NAME} PUBLIC)
+else()
+  target_compile_options(
+    ${LIB_TARGET_NAME}
+    PRIVATE
+    -fexceptions
+    -frtti
+    -std=c++20
+    -Wall
+    -Wpedantic
+    -Wno-gnu-zero-variadic-macro-arguments
   )
 endif()
 


### PR DESCRIPTION
Summary:
---------

Trying to use `react-native-slider` with react-native 0.81.0-rc.5 will cause an insta crash in the app due to an issue when parsing `RNCSliderProps` on Android

<img width="1625" height="281" alt="image" src="https://github.com/user-attachments/assets/012b58e5-a3ff-4d68-96d2-deaeb8cf6f38" />

These changes are related to the Props 2.0 project and require us to set the necessary flags and definitions in Cmake, by using `target_compile_reactnative_options` this can be done automatically instead of setting them manually.
 


Test Plan:
----------

1. `npx @react-native-community/cli@latest init RC5 --skip-install --version next`
2. `yarn add @react-native-community/slider`
3. patch `package/android/src/main/jni/CMakeLists.txt`