### PR TITLE
Migrate away from `ContextContainer::Shared`

### DIFF
--- a/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderMeasurementsManager.h
+++ b/package/common/cpp/react/renderer/components/RNCSlider/RNCSliderMeasurementsManager.h
@@ -10,13 +10,13 @@ namespace facebook::react {
     class RNCSliderMeasurementsManager {
     public:
         RNCSliderMeasurementsManager(
-                const ContextContainer::Shared &contextContainer)
+                const std::shared_ptr<const ContextContainer> &contextContainer)
                 : contextContainer_(contextContainer) {}
 
         Size measure(SurfaceId surfaceId, LayoutConstraints layoutConstraints) const;
 
     private:
-        const ContextContainer::Shared contextContainer_;
+        const std::shared_ptr<const ContextContainer> contextContainer_;
         mutable std::mutex mutex_;
         mutable bool hasBeenMeasured_ = false;
         mutable Size cachedMeasurement_{};


### PR DESCRIPTION
Summary:
---------

`ContextContainer::Shared` is deprecated (see https://github.com/facebook/react-native/blob/f936780cd5c0c17797f9d2bbc8f5cee81c2eefce/packages/react-native/ReactCommon/react/utils/ContextContainer.h#L28-L30)

You should be using `std::shared_ptr<const ContextContainer>`.


Test Plan:
----------

This is a 1:1 replacement. CI tests should be necessary.