### PR TITLE
iOS New Arch: shouldBeRecycled = NO

### DIFF
--- a/package/ios/RNCSliderComponentView.mm
+++ b/package/ios/RNCSliderComponentView.mm
@@ -31,6 +31,10 @@ using namespace facebook::react;
     return concreteComponentDescriptorProvider<RNCSliderComponentDescriptor>();
 }
 
++ (BOOL)shouldBeRecycled {
+  return NO;
+}
+
 - (instancetype)initWithFrame:(CGRect)frame
 {
     if (self = [super initWithFrame:frame]) {


### PR DESCRIPTION
Fixes #739 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `+shouldBeRecycled` returning `NO` to `RNCSliderComponentView` to disable view recycling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea4c3c7a40128008596bff0afe77df7850ee5191. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->