### PR TITLE
docs: add newArch is required for >=5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To use this library you need to ensure you are using the correct version of Reac
 
 | `@react-native-community/slider` version | Required React Native Version |
 | ---------------------------------------- | ---------------------------- |
-| `5.0.0`                                  | `>=0.76`                     |
+| `5.0.0`                                  | `>=0.76 (new architecture only)` |
 | `4.5.1`                                  | `>=0.69`                     |
 | `4.3.0`                                  | `>=0.64`                     |
 | `4.x.x`                                  | `>=0.60`; `>=0.62` (on Windows); |


### PR DESCRIPTION
Summary:
---------

There is nowhere in your readme.md that you need newArch for v5. So I've at least one mention of that.

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->