### PR TITLE
fix: iOS honor RCTI18nUtil RTL on New Architecture

### DIFF
--- a/package/ios/RNCSliderComponentView.mm
+++ b/package/ios/RNCSliderComponentView.mm
@@ -7,6 +7,7 @@
 #import <react/renderer/components/RNCSlider/Props.h>
 #import <react/renderer/components/RNCSlider/RCTComponentViewHelpers.h>
 #import <React/RCTBridge+Private.h>
+#import <React/RCTI18nUtil.h>
 #import "RCTImagePrimitivesConversions.h"
 #import <React/RCTImageLoaderProtocol.h>
 #import "RCTFabricComponentsPlugins.h"
@@ -41,6 +42,15 @@ using namespace facebook::react;
         static const auto defaultProps = std::make_shared<const RNCSliderProps>();
         _props = defaultProps;
         slider = [[RNCSlider alloc] initWithFrame:self.bounds];
+
+        // Honor app-forced RTL (RCTI18nUtil) instead of device locale
+        BOOL appIsRTL = [[RCTI18nUtil sharedInstance] isRTL];
+        UISemanticContentAttribute attr = appIsRTL
+            ? UISemanticContentAttributeForceRightToLeft
+            : UISemanticContentAttributeForceLeftToRight;
+        slider.semanticContentAttribute = attr;
+        self.semanticContentAttribute = attr;
+
         [slider addTarget:self action:@selector(sliderValueChanged:)
          forControlEvents:UIControlEventValueChanged];
         [slider addTarget:self action:@selector(sliderTouchStart:)


### PR DESCRIPTION
Summary:
---------

On the New Architecture (Fabric) on iOS, the slider follows the **device** language instead of the **app's** language.
So if the app is in (RTL) and forced with:
```js
I18nManager.forceRTL(true)
```
 but the device is in English (LTR), the slider appears flipped — the filled side and drag direction don't match the rest of the app's UI. Same problem in reverse: English app on an Arabic device.

This fix makes the slider follow the app's direction (`I18nManager.forceRTL`) regardless of what the device is set to.

- Android already works correctly, so no changes there.
- The old architecture (Paper) is unaffected.

https://github.com/user-attachments/assets/f09d124a-3d92-4ec1-977a-0e1edde4f78e

https://github.com/user-attachments/assets/8e17770a-a134-45af-975c-2b9cc05d6cc2


Test Plan:
----------

Tested on the New Architecture (Fabric) on iOS with all four combinations of device locale × app forced direction. The slider's filled track grows from the value-minimum side as defined by the **app**'s direction in every case:

| Device locale | App forced direction | Expected filled-from-side | Result |
|---|---|---|---|
| LTR (en_US) | LTR | Left | ✅ |
| LTR (en_US) | RTL (`forceRTL(true)`) | Right | ✅ |
| RTL (ar_SA) | LTR (`forceRTL(false)`) | Left | ✅ |
| RTL (ar_SA) | RTL | Right | ✅ |

Also verified:
- Dragging toward the maximum side increases the value, regardless of device locale.
- `tapToSeek` taps land at the correct value in all four combinations.
- The `inverted` prop still works on top of the new baseline direction.
- No regressions on Android.

Repro steps (before the fix):
1. Run on iOS with New Architecture enabled.
2. Ensure iOS project has a localized Info.plist example for Arabic (RTL language)
3. Set device language to English; in the app, call `I18nManager.forceRTL(true)` and restart.
4. Observe the slider's filled track is on the **left** (incorrect — should be on the right to match the app's RTL UI).
5. Apply this patch, rebuild, and observe the filled track is now on the **right**.
