### PR TITLE
perf: memoize options/thumbImage and stop mutating on inverted

### DIFF
--- a/package/src/Slider.tsx
+++ b/package/src/Slider.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import {
   Image,
   Platform,
@@ -239,11 +239,15 @@ const SliderComponent = (
   const defaultStep = (maximumValue - minimumValue) / stepResolution;
   const stepLength = step || defaultStep;
 
-  const options = Array.from(
-    {
-      length: (step ? defaultStep : stepResolution) + 1,
-    },
-    (_, index) => minimumValue + index * stepLength,
+  const options = useMemo(
+    () =>
+      Array.from(
+        {
+          length: (step ? defaultStep : stepResolution) + 1,
+        },
+        (_, index) => minimumValue + index * stepLength,
+      ),
+    [step, defaultStep, stepResolution, minimumValue, stepLength],
   );
 
   const defaultStyle =
@@ -284,6 +288,16 @@ const SliderComponent = (
 
   const passedValue = Number.isNaN(value) || !value ? undefined : value;
 
+  const resolvedThumbImage = useMemo(
+    () =>
+      Platform.OS === 'web'
+        ? props.thumbImage
+        : props.StepMarker || !props.thumbImage
+        ? undefined
+        : Image.resolveAssetSource(props.thumbImage as ImageSourcePropType),
+    [props.thumbImage, props.StepMarker],
+  );
+
   useEffect(() => {
     if (lowerLimit >= upperLimit) {
       console.warn(
@@ -320,13 +334,7 @@ const SliderComponent = (
         lowerLimit={lowerLimit}
         upperLimit={upperLimit}
         accessibilityState={_accessibilityState}
-        thumbImage={
-          Platform.OS === 'web'
-            ? props.thumbImage
-            : props.StepMarker || !props.thumbImage
-            ? undefined
-            : Image.resolveAssetSource(props.thumbImage as ImageSourcePropType)
-        }
+        thumbImage={resolvedThumbImage}
         ref={forwardedRef}
         style={[
           sliderStyle,

--- a/package/src/components/StepsIndicator.tsx
+++ b/package/src/components/StepsIndicator.tsx
@@ -52,7 +52,7 @@ export const StepsIndicator = ({
     };
   }, [sliderWidth]);
 
-  const values = isLTR ? options.reverse() : options;
+  const values = isLTR ? options.slice().reverse() : options;
 
   const renderStepIndicator = useCallback(
     (i: number, index: number) => {


### PR DESCRIPTION
Summary:
---------

Three marginal-but-easy perf/correctness fixes in the JS layer. No public API changes, no behaviour changes for end users.

1. **Memoize `options` in `Slider.tsx`** — the `Array.from(...)` call rebuilt the array on every render. Wrapping it in `useMemo` also restores the effectiveness of `StepsIndicator`'s existing `useCallback`/`useMemo`, which currently bust every render because the parent hands them a freshly allocated array.
2. **Memoize the resolved `thumbImage` in `Slider.tsx`** — `Image.resolveAssetSource(...)` ran on every render. Memoized on `props.thumbImage`/`props.StepMarker`.
3. **Stop mutating `options` in `StepsIndicator.tsx`** — `options.reverse()` mutates the array passed in from the parent in place. Switched to `options.slice().reverse()`. Mostly a correctness fix; with the parent now memoizing the array, the in-place reverse would also have re-reversed the same array each render.

Test Plan:
----------

- `npm test` from `package/` → 4 suites, 16 tests passing.
- `npm run lint` from `package/` → no new warnings introduced.
- Recommended smoke test in the example app: scenarios with `inverted`, with non-zero `step`, and with `thumbImage` set, to confirm no visual regression.