### PR TITLE
fix(android): stop leaking executor thread in getBitmapDrawable

### DIFF
--- a/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
+++ b/package/android/src/main/java/com/reactnativecommunity/slider/ReactSlider.java
@@ -280,33 +280,38 @@ public class ReactSlider extends AppCompatSeekBar {
   private BitmapDrawable getBitmapDrawable(final String uri) {
     BitmapDrawable bitmapDrawable = null;
     ExecutorService executorService = Executors.newSingleThreadExecutor();
-    Future<BitmapDrawable> future = executorService.submit(new Callable<BitmapDrawable>() {
-      @Override
-      public BitmapDrawable call() {
-        BitmapDrawable bitmapDrawable = null;
-        try {
-          Bitmap bitmap = null;
-          if (uri.startsWith("http://") || uri.startsWith("https://") ||
-              uri.startsWith("file://") || uri.startsWith("asset://") || uri.startsWith("data:")) {
-            bitmap = BitmapFactory.decodeStream(new URL(uri).openStream());
-          } else {
-            int drawableId = getResources()
-                .getIdentifier(uri, "drawable", getContext()
-                .getPackageName());
-            bitmap = BitmapFactory.decodeResource(getResources(), drawableId);
-          }
-
-          bitmapDrawable = new BitmapDrawable(getResources(), bitmap);
-        } catch (Exception e) {
-          e.printStackTrace();
-        }
-        return bitmapDrawable;
-      }
-    });
     try {
-      bitmapDrawable = future.get();
-    } catch (Exception e) {
-      e.printStackTrace();
+      Future<BitmapDrawable> future = executorService.submit(new Callable<BitmapDrawable>() {
+        @Override
+        public BitmapDrawable call() {
+          BitmapDrawable bitmapDrawable = null;
+          try {
+            Bitmap bitmap = null;
+            if (uri.startsWith("http://") || uri.startsWith("https://") ||
+                uri.startsWith("file://") || uri.startsWith("asset://") || uri.startsWith("data:")) {
+              bitmap = BitmapFactory.decodeStream(new URL(uri).openStream());
+            } else {
+              int drawableId = getResources()
+                  .getIdentifier(uri, "drawable", getContext()
+                  .getPackageName());
+              bitmap = BitmapFactory.decodeResource(getResources(), drawableId);
+            }
+
+            bitmapDrawable = new BitmapDrawable(getResources(), bitmap);
+          } catch (Exception e) {
+            e.printStackTrace();
+          }
+          return bitmapDrawable;
+        }
+      });
+      try {
+        bitmapDrawable = future.get();
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    } finally {
+      // Without this, every call leaks the worker thread for the lifetime of the process.
+      executorService.shutdown();
     }
     return bitmapDrawable;
   }


### PR DESCRIPTION
Summary:
---------

`ReactSlider.getBitmapDrawable` creates `Executors.newSingleThreadExecutor()` per call and never shuts it down, so every `setThumbImage` call leaks the worker thread for the lifetime of the process. Wrapped the submit/get in a try/finally and shut down the executor once the bitmap decode is complete.

The submit-then-immediately-`get()` pattern itself is preserved — the off-thread decode is presumably there to keep `BitmapFactory.decodeStream(new URL(uri).openStream())` off the main thread for StrictMode. Behaviour is unchanged; only the now-idle worker thread is reclaimed.

Test Plan:
----------

The Android slider has no JVM unit tests in this repo, so verification is by inspection.

Recommended manual check: mount/unmount a slider with a `thumbImage` repeatedly and confirm the live thread count does not grow indefinitely (e.g. via Android Studio's Profiler).