### PR TITLE
fix: declare react and react-native as peer dependencies

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -53,6 +53,10 @@
     "react-test-renderer": "^19.2.0",
     "typescript": "^5.0.4"
   },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/callstack/react-native-slider.git"


### PR DESCRIPTION
## Summary

The published package declares `react` and `react-native` only under `devDependencies` and has no `peerDependencies` field, so package managers have no way to know the slider expects them to be provided by the host app.

This breaks in pnpm monorepos. With pnpm's default (strict) node-linker, a package can only resolve the dependencies it explicitly declares. Because the slider does not declare `react`/`react-native` as deps or peers, pnpm does not link the host app's copies to it. The result is a second copy of React getting loaded, which throws the classic:

> Invalid hook call. Hooks can only be called inside of the body of a function component.

Declaring `react` and `react-native` as peer dependencies lets the package manager deduplicate them against whatever the host app already has installed. I used wide `*` ranges to match the convention already used by other callstack React Native libraries (for example react-native-paper), since the slider works across a broad range of React Native versions and should not artificially constrain consumers. The pinned dev versions are kept as-is for the example app and tests.

Fixes #769

## Test Plan

- `node -e "JSON.parse(require('fs').readFileSync('package/package.json'))"` parses with no error.
- Confirmed the new `peerDependencies` block resolves to `{"react":"*","react-native":"*"}` and that `devDependencies` still pins `react ^19.2.0` / `react-native ^0.81.4`.
- The change is limited to adding the `peerDependencies` field; no source or build behavior changes.