### PR TITLE
fix(ios): load thumbImage/trackImage without the legacy bridge on bridgeless (new arch)

### DIFF
--- a/package/ios/RNCSliderComponentView.mm
+++ b/package/ios/RNCSliderComponentView.mm
@@ -274,14 +274,6 @@ using namespace facebook::react;
 }
 
 
-// Legacy-bridge path first: when the bridge is present, RCTImageLoader provides caching,
-// decode-time sizing and custom RCTImageURLLoader schemes. On bridgeless, [RCTBridge currentBridge]
-// may be nil or expose an ImageLoader that cannot load
-// (https://github.com/reactwg/react-native-new-architecture/discussions/31#discussioncomment-2717047),
-// so fall back to fetching the bytes directly with NSURLSession. The fallback covers file://
-// (bundled require() assets) and http(s) (Metro in dev, remote images) and honours custom request
-// headers; it does not support RCTImageURLLoader plugin schemes (e.g. ph://) or ImageLoader's
-// resizing and caching. TODO: replace both paths with the Fabric ImageManager pipeline.
 - (void)loadImageFromImageSource:(ImageSource)source completionBlock:(RNCLoadImageCompletionBlock)completionBlock failureBlock:(RNCLoadImageFailureBlock)failureBlock
 {
     NSString *uri = [[NSString alloc] initWithUTF8String:source.uri.c_str()];

--- a/package/ios/RNCSliderComponentView.mm
+++ b/package/ios/RNCSliderComponentView.mm
@@ -9,6 +9,7 @@
 #import <React/RCTBridge+Private.h>
 #import "RCTImagePrimitivesConversions.h"
 #import <React/RCTImageLoaderProtocol.h>
+#import <React/RCTUtils.h>
 #import "RCTFabricComponentsPlugins.h"
 #import "RNCSlider.h"
 
@@ -273,23 +274,61 @@ using namespace facebook::react;
 }
 
 
-// TODO temporarily using bridge, workaround for https://github.com/reactwg/react-native-new-architecture/discussions/31#discussioncomment-2717047, rewrite when Meta comes with a solution.
+// Legacy-bridge path first: when the bridge is present, RCTImageLoader provides caching,
+// decode-time sizing and custom RCTImageURLLoader schemes. On bridgeless, [RCTBridge currentBridge]
+// may be nil or expose an ImageLoader that cannot load
+// (https://github.com/reactwg/react-native-new-architecture/discussions/31#discussioncomment-2717047),
+// so fall back to fetching the bytes directly with NSURLSession. The fallback covers file://
+// (bundled require() assets) and http(s) (Metro in dev, remote images) and honours custom request
+// headers; it does not support RCTImageURLLoader plugin schemes (e.g. ph://) or ImageLoader's
+// resizing and caching. TODO: replace both paths with the Fabric ImageManager pipeline.
 - (void)loadImageFromImageSource:(ImageSource)source completionBlock:(RNCLoadImageCompletionBlock)completionBlock failureBlock:(RNCLoadImageFailureBlock)failureBlock
 {
     NSString *uri = [[NSString alloc] initWithUTF8String:source.uri.c_str()];
-    if ((BOOL)uri.length) {
-        [[[RCTBridge currentBridge] moduleForName:@"ImageLoader"]
-        loadImageWithURLRequest:NSURLRequestFromImageSource(source)
-        size:CGSizeMake(source.size.width, source.size.height)
-        scale:source.scale
-        clipped:NO
-        resizeMode:RCTResizeModeCover
-        progressBlock:nil
-        partialLoadBlock:nil
-        completionBlock:completionBlock];
-    } else {
+    if (!(BOOL)uri.length) {
         failureBlock();
+        return;
     }
+
+    NSURLRequest *request = NSURLRequestFromImageSource(source);
+    CGFloat scale = source.scale > 0 ? source.scale : RCTScreenScale();
+
+    void (^loadDirectly)(void) = ^{
+        [[[NSURLSession sharedSession] dataTaskWithRequest:request
+                                         completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            UIImage *image = data ? [UIImage imageWithData:data scale:scale] : nil;
+            // The session queue is a background queue; callers touch UIKit, so hop to main.
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (image) {
+                    completionBlock(nil, image);
+                } else {
+                    failureBlock();
+                }
+            });
+        }] resume];
+    };
+
+    id<RCTImageLoaderProtocol> imageLoader = [[RCTBridge currentBridge] moduleForName:@"ImageLoader"];
+    if (!imageLoader) {
+        loadDirectly();
+        return;
+    }
+
+    [imageLoader
+    loadImageWithURLRequest:request
+    size:CGSizeMake(source.size.width, source.size.height)
+    scale:source.scale
+    clipped:NO
+    resizeMode:RCTResizeModeCover
+    progressBlock:nil
+    partialLoadBlock:nil
+    completionBlock:^(NSError *error, UIImage *image) {
+        if (image) {
+            completionBlock(nil, image);
+        } else {
+            loadDirectly();
+        }
+    }];
 }
 
 - (void)setInverted:(BOOL)inverted


### PR DESCRIPTION
## Summary

On bridgeless React Native (the default new-architecture mode since RN 0.74+), `thumbImage`, `trackImage`, `minimumTrackImage` and `maximumTrackImage` silently fail to render on iOS. `loadImageFromImageSource` resolves the ImageLoader through `[RCTBridge currentBridge]` (flagged by the existing TODO in the file), which doesn't reliably provide a working ImageLoader without the legacy bridge — the completion never delivers an image, and the slider falls back to the default thumb.

Fixes #773

## Fix

Keep the existing ImageLoader path as the first attempt (no behaviour change where it works). If the module is unavailable **or** returns no image, fall back to fetching the image directly with `NSURLSession` using the same `NSURLRequest` — this covers bundled `file://` assets, Metro URLs in dev, and remote images, and honours custom request headers. The retry-on-no-image (rather than only on missing module) is deliberate: on bridgeless, the interop layer can hand back an ImageLoader instance that exists but cannot load, so gating on module presence alone would not fix the bug.

Details:
- The `NSURLSession` completion invokes the callbacks on the main queue, since `failureBlock` call sites in `updateProps` mutate UIKit directly and previously only ran synchronously on the main thread.
- The scale fallback uses `RCTScreenScale()` (not `[UIScreen mainScreen]`, which is unavailable on visionOS — this pod declares visionOS support).
- The stale TODO comment is replaced with one describing the current dual-path behaviour.

Refactored `loadImageFromImageSource` uses legacy-bridge path first: when the bridge is present, RCTImageLoader provides caching, decode-time sizing and custom RCTImageURLLoader schemes.
On bridgeless, [RCTBridge currentBridge] may be nil or expose an ImageLoader that cannot load
(https://github.com/reactwg/react-native-new-architecture/discussions/31#discussioncomment-2717047),
so fall back to fetching the bytes directly with NSURLSession.
The fallback covers file:// (bundled require() assets) and http(s) (Metro in dev, remote images) and honours custom request headers;
it does not support RCTImageURLLoader plugin schemes (e.g. ph://) or ImageLoader's
resizing and caching. TODO: replace both paths with the Fabric ImageManager pipeline.

## Known limitations of the fallback

These apply only on bridgeless, where the fallback is effectively the primary path, and match the documented `thumbImage` API surface (static local/network images):

- `RCTImageURLLoader` plugin schemes (e.g. `ph://`, custom app-registered schemes) are not supported by `NSURLSession` and will fail; they were undocumented for this component but worked via the bridge ImageLoader on the old architecture.
- The fallback does not apply ImageLoader's decode-time resizing (`source.size` + cover mode) or decoded-image caching. A remote `{uri, width, height}` source without `thumbSize` decodes and renders at intrinsic bitmap size.

Both could be addressed by resolving `RCTImageLoader` from the new-arch module registry (or ultimately the Fabric ImageManager pipeline) — left out of scope here to keep this a minimal fix for #773.

## Test plan

Verified in a production Expo SDK 56 / RN 0.85 app (bridgeless, new arch): before the change `thumbImage` renders the default circle; after it, the custom thumb renders correctly in both dev (Metro-served asset) and release (bundled asset). Android untouched.
